### PR TITLE
fix(jwt header): Fixing the formatting for scopes and "embed" in jwt header

### DIFF
--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -94,9 +94,15 @@ rw==
 
         var embedClaim = jwtToken.Claims.First(c => c.Type == JWTScope.Embed).Value;
         var embedData = JsonSerializer.Deserialize<Dictionary<string, object>>(embedClaim);
+        List<string> scopesData = jwtToken.Claims
+            .Where(c => c.Type == "scopes")
+            .Select(c => c.Value)
+            .ToList();
 
         Assert.Contains(JWTScope.Embed, jwtToken.Claims.Select(c => c.Type).ToList());
+        Assert.That(scopesData, Is.EqualTo(new[] { JWTScope.Embed }));
         Assert.NotNull(embedData);
+        Assert.That(embedClaim, Is.EqualTo(System.Text.Json.JsonSerializer.Serialize(_embedParams)));
         Assert.That(embedData["currency"].ToString(), Is.EqualTo("USD"));
     }
 

--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -120,10 +120,8 @@ public class Auth
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
         };
 
-        foreach (var scope in scopes)
-        {
-            claims.Add(new Claim("scopes", scope));
-        }
+        var scopesJson = System.Text.Json.JsonSerializer.Serialize(scopes);
+        claims.Add(new Claim("scopes", scopesJson, JsonClaimValueTypes.JsonArray));
 
         if (!string.IsNullOrEmpty(checkoutSessionId))
         {
@@ -133,7 +131,7 @@ public class Auth
         if (scopes.Contains(JWTScope.Embed) && embedParams != null)
         {
             claims.Add(
-                new Claim(JWTScope.Embed, System.Text.Json.JsonSerializer.Serialize(embedParams))
+                new Claim(JWTScope.Embed, System.Text.Json.JsonSerializer.Serialize(embedParams), JsonClaimValueTypes.Json)
             );
         }
 


### PR DESCRIPTION
Fixing the formatting for `scopes` and `embed` in jwt header
Jira: [TA-12017](https://gr4vy.atlassian.net/browse/TA-12017)

[TA-12017]: https://gr4vy.atlassian.net/browse/TA-12017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ