### PR TITLE
chore: bump System.IdentityModel.Tokens.Jwt to 8.17.0

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ csharp:
   version: 2.7.62
   additionalDependencies:
     - package: System.IdentityModel.Tokens.Jwt
-      version: 8.9.0
+      version: 8.17.0
   author: Gr4vy
   baseErrorName: BaseException
   clientServerStatusCodesAsErrors: true

--- a/src/Gr4vy/Gr4vy.csproj
+++ b/src/Gr4vy/Gr4vy.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="newtonsoft.json" Version="13.0.3" />
     <PackageReference Include="nodatime" Version="3.1.9" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Bump `System.IdentityModel.Tokens.Jwt` from `8.9.0` → `8.17.0`
- Drops transitive `Microsoft.Bcl.Memory` dependency (absent from `project.assets.json` post-restore)

## Why
Stay current with Microsoft.IdentityModel.* security/bug fixes and shed the `Microsoft.Bcl.Memory` transitive.

## Verification
- `dotnet restore` clean
- `dotnet build` succeeds (only pre-existing CS8601 warnings)
- `dotnet list package --include-transitive` shows IdentityModel suite at `8.17.0`; no `Microsoft.Bcl.Memory`
- Note: `dotnet nuget why` unavailable on local SDK 8.0.124 (requires 8.0.400+); verified via assets file instead

## Test plan
- [ ] CI green
- [ ] Confirm no runtime JWT regressions in downstream consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)