### PR TITLE
fix: tri-state nullable for *Update request models

### DIFF
--- a/.github/workflows/patch_speakeasy_regen.yaml
+++ b/.github/workflows/patch_speakeasy_regen.yaml
@@ -26,6 +26,17 @@ on:
 permissions:
   contents: read
 
+# Multiple PR events (opened, synchronize) can fire close together on the
+# same regen branch — most often when Speakeasy follows the regen commit
+# with an "empty trigger" commit. Without this guard, two patch runs can
+# race on the push and one fails non-fast-forward, surfacing a noisy
+# failure notification even though the later run would have self-healed.
+# Group by PR number and cancel anything in-flight when a newer event
+# arrives.
+concurrency:
+  group: patch-speakeasy-regen-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   patch:
     if: >-

--- a/.github/workflows/patch_speakeasy_regen.yaml
+++ b/.github/workflows/patch_speakeasy_regen.yaml
@@ -8,35 +8,57 @@ name: Patch Speakeasy Regen
 # the tri-state patch in `.speakeasy/scripts/patch_update_models.py` to any
 # *Update.cs files the regen reset, and pushes the result back.
 #
-# The push uses DISPATCH_ACCESS_TOKEN (a PAT) rather than GITHUB_TOKEN so
-# that the follow-up commit retriggers the CI workflow on the patched code
-# — GitHub does not re-run workflows for pushes authenticated with
-# GITHUB_TOKEN.
+# Security model: the workflow filters to same-repo PRs whose head branch
+# matches the Speakeasy-regen prefix. It checks out the base branch (a
+# trusted source for the patch script) and the PR head (untrusted) into
+# separate worktrees, both with `persist-credentials: false` so the PAT
+# never ends up in `.git/config`. The patch script is invoked from the
+# trusted checkout. The PAT (DISPATCH_ACCESS_TOKEN) is supplied only on
+# the final `git push` command via an inlined URL — never persisted to
+# the filesystem. We need a PAT (not GITHUB_TOKEN) at push time because
+# GitHub will not retrigger the CI workflow for commits authenticated
+# with GITHUB_TOKEN.
 
 on:
   pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   patch:
-    if: ${{ startsWith(github.event.pull_request.head.ref, 'speakeasy-sdk-regen-') }}
+    if: >-
+      ${{ github.event.pull_request.head.repo.full_name == github.repository
+       && startsWith(github.event.pull_request.head.ref, 'speakeasy-sdk-regen-') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted source of patch script)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: base
+          persist-credentials: false
+
+      - name: Checkout PR head (untrusted)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          path: head
+          persist-credentials: false
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Apply tri-state nullable patch to *Update models
-        run: python3 .speakeasy/scripts/patch_update_models.py
-      - name: Commit and push patch
+
+      - name: Apply tri-state nullable patch using trusted script against PR head
+        run: python3 base/.speakeasy/scripts/patch_update_models.py head
+
+      - name: Commit and push patch (PAT scoped to push command only)
+        working-directory: head
+        env:
+          PAT: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
         run: |
           if git diff --quiet -- src/Gr4vy/Models/Components; then
             echo "No tri-state patches to apply; nothing to commit."
@@ -46,4 +68,5 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add src/Gr4vy/Models/Components
           git commit -m "fix: apply tri-state nullable patch to *Update models"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git" \
+            "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/.github/workflows/patch_speakeasy_regen.yaml
+++ b/.github/workflows/patch_speakeasy_regen.yaml
@@ -1,0 +1,49 @@
+name: Patch Speakeasy Regen
+
+# Speakeasy's reusable generation workflow does not expose its job outputs
+# at the `on.workflow_call.outputs` level, so a caller cannot read
+# `needs.generate.outputs.csharp_regenerated` or `branch_name`. We can't
+# chain a patch step inside `sdk_generation.yaml` reliably. Instead, this
+# workflow triggers on the PR that the generation workflow opens, applies
+# the tri-state patch in `.speakeasy/scripts/patch_update_models.py` to any
+# *Update.cs files the regen reset, and pushes the result back.
+#
+# The push uses DISPATCH_ACCESS_TOKEN (a PAT) rather than GITHUB_TOKEN so
+# that the follow-up commit retriggers the CI workflow on the patched code
+# — GitHub does not re-run workflows for pushes authenticated with
+# GITHUB_TOKEN.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    if: ${{ startsWith(github.event.pull_request.head.ref, 'speakeasy-sdk-regen-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Apply tri-state nullable patch to *Update models
+        run: python3 .speakeasy/scripts/patch_update_models.py
+      - name: Commit and push patch
+        run: |
+          if git diff --quiet -- src/Gr4vy/Models/Components; then
+            echo "No tri-state patches to apply; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/Gr4vy/Models/Components
+          git commit -m "fix: apply tri-state nullable patch to *Update models"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/patch_speakeasy_regen.yaml
+++ b/.github/workflows/patch_speakeasy_regen.yaml
@@ -36,14 +36,14 @@ jobs:
       - name: Checkout base branch (trusted source of patch script)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.sha }}
           path: base
           persist-credentials: false
 
       - name: Checkout PR head (untrusted)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: head
           persist-credentials: false
 
@@ -70,3 +70,21 @@ jobs:
           git commit -m "fix: apply tri-state nullable patch to *Update models"
           git push "https://x-access-token:${PAT}@github.com/${{ github.repository }}.git" \
             "HEAD:${{ github.event.pull_request.head.ref }}"
+
+  notify:
+    needs: patch
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.patch.result == 'failure' }}
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
+        env:
+          SLACK_USERNAME: C# SDK
+          SLACK_TITLE: C# SDK
+          SLACK_WEBHOOK: ${{ secrets.SLACK_SDK_WEBHOOK_URL }}
+          SLACK_CHANNEL: sdk-updates
+          SLACK_MSG_AUTHOR: gr4vy-code
+          SLACK_ICON_EMOJI: ":gr4vy:"
+          SLACK_COLOR: failure
+          SLACK_MESSAGE_ON_FAILURE: "Tri-state nullable patch failed on regen PR ${{ github.event.pull_request.html_url }}"
+          SLACK_FOOTER: ""

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -34,7 +34,7 @@ jobs:
   notify:
     needs: generate
     runs-on: ubuntu-latest
-    if: ${{ contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2

--- a/.speakeasy/scripts/patch_update_models.py
+++ b/.speakeasy/scripts/patch_update_models.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Post-generation patch for *Update.cs models.
+
+Speakeasy emits update-request models with auto-properties like:
+
+    [JsonProperty("display_name")]
+    public string? DisplayName { get; set; } = null;
+
+Combined with the global `NullValueHandling.Ignore` setting, this gives a
+two-state field: "unset" and "value", but no way to send an explicit `null`
+to clear a stored field. Setting `DisplayName = null` is indistinguishable
+from leaving it untouched, and both result in the key being omitted.
+
+Customers doing partial updates rely on the "unset means omit" behavior, so
+we cannot flip the global serializer to `Include`. Instead, this script
+rewrites each auto-property to a backing-field + `ShouldSerialize<X>()`
+pattern that gives three states:
+
+    * never assigned  -> key omitted (unchanged behavior)
+    * assigned null   -> key sent as null (new: clear-via-null)
+    * assigned value  -> key sent as value (unchanged behavior)
+
+The `ShouldSerialize<X>()` method is honored by Newtonsoft.Json and takes
+precedence over the global `NullValueHandling.Ignore`, so we also flip the
+attribute to `NullValueHandling.Include` on each touched property.
+
+Properties whose generated default is a non-null literal (e.g. `= false`)
+are initialized with `_xSet = true` to preserve today's behavior of sending
+that default value on the wire.
+
+The script is idempotent: re-running on already-patched code is a no-op
+(the auto-property regex no longer matches the rewritten form).
+
+Forward-compatibility: if Speakeasy's C# generator ever ships tri-state
+nullable natively, the generated file is expected to expose
+`ShouldSerialize*` methods (the only way Newtonsoft.Json honors per-field
+omission while keeping `NullValueHandling.Include`). When this script
+detects `ShouldSerialize` in a candidate file it treats that file as
+already tri-stateful and leaves it alone. The patch can then be retired
+file-by-file as the generator catches up, and removed entirely once no
+file needs it.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROP_RE = re.compile(
+    r"(?P<indent>[ \t]*)"
+    r"(?P<attr>\[JsonProperty\([^\]]*\)\])\s*\n"
+    r"[ \t]*public\s+(?P<type_and_name>.+?)\s*\{\s*get;\s*set;\s*\}\s*=\s*(?P<default>[^;]+);",
+    re.MULTILINE,
+)
+
+NULL_VALUE_HANDLING_RE = re.compile(
+    r",?\s*NullValueHandling\s*=\s*NullValueHandling\.\w+"
+)
+
+
+def force_null_value_handling_include(attr: str) -> str:
+    """Ensure the [JsonProperty(...)] attribute has NullValueHandling.Include.
+
+    Replaces any existing `NullValueHandling = NullValueHandling.X` (Ignore,
+    Default, etc.) with `Include`, and appends the argument if absent. We do
+    this unconditionally rather than only when the argument is missing so the
+    patch stays correct if Speakeasy ever starts emitting a different value.
+    """
+    if "NullValueHandling.Include" in attr:
+        return attr
+    stripped = NULL_VALUE_HANDLING_RE.sub("", attr)
+    return stripped[:-2] + ", NullValueHandling = NullValueHandling.Include)]"
+
+
+def patch_source(source: str) -> str | None:
+    matches = list(PROP_RE.finditer(source))
+    if not matches:
+        return None
+
+    out: list[str] = []
+    last_end = 0
+    for m in matches:
+        indent = m.group("indent")
+        attr = m.group("attr")
+        type_and_name = m.group("type_and_name").strip()
+        default = m.group("default").strip()
+
+        space_idx = type_and_name.rfind(" ")
+        type_str = type_and_name[:space_idx].strip()
+        name = type_and_name[space_idx + 1 :].strip()
+
+        new_attr = force_null_value_handling_include(attr)
+
+        backing = "_" + name[0].lower() + name[1:]
+        set_flag = backing + "Set"
+        initial_set = "true" if default != "null" else "false"
+
+        replacement = (
+            f"{indent}{new_attr}\n"
+            f"{indent}public {type_str} {name}\n"
+            f"{indent}{{\n"
+            f"{indent}    get => {backing};\n"
+            f"{indent}    set\n"
+            f"{indent}    {{\n"
+            f"{indent}        {backing} = value;\n"
+            f"{indent}        {set_flag} = true;\n"
+            f"{indent}    }}\n"
+            f"{indent}}}\n"
+            f"\n"
+            f"{indent}private {type_str} {backing} = {default};\n"
+            f"\n"
+            f"{indent}private bool {set_flag} = {initial_set};\n"
+            f"\n"
+            f"{indent}public bool ShouldSerialize{name}() => {set_flag};"
+        )
+
+        out.append(source[last_end : m.start()])
+        out.append(replacement)
+        last_end = m.end()
+
+    out.append(source[last_end:])
+    return "".join(out)
+
+
+def is_update_request_model(path: Path) -> bool:
+    """Filter for files matching *Update.cs.
+
+    The `*Update.cs` glob in `main()` already excludes the only known
+    noun-form `Updater` files in this codebase (AccountUpdaterJob.cs,
+    AccountUpdaterOptions.cs, etc.) because they don't end in `Update.cs`.
+    The AccountUpdater* guard is a belt-and-suspenders check in case a
+    future schema introduces e.g. `AccountUpdaterUpdate.cs`, which would
+    be ambiguous; broaden it if/when such cases appear.
+    """
+    name = path.name
+    if not name.endswith("Update.cs"):
+        return False
+    if name.startswith("AccountUpdater"):
+        return False
+    return True
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    components = repo_root / "src" / "Gr4vy" / "Models" / "Components"
+    if not components.is_dir():
+        print(f"error: components directory not found: {components}", file=sys.stderr)
+        return 1
+
+    patched = 0
+    skipped = 0
+    native = 0
+    for path in sorted(components.glob("*Update.cs")):
+        if not is_update_request_model(path):
+            continue
+        original = path.read_text()
+        if "ShouldSerialize" in original:
+            # The generator (or a previous run) has already emitted tri-state
+            # for this model. Leave it alone so this patch retires cleanly
+            # once Speakeasy ships native support.
+            print(f"native tri-state, leaving alone: {path.relative_to(repo_root)}")
+            native += 1
+            continue
+        result = patch_source(original)
+        if result is None or result == original:
+            print(f"skipped (no auto-property matches): {path.relative_to(repo_root)}")
+            skipped += 1
+            continue
+        path.write_text(result)
+        print(f"patched: {path.relative_to(repo_root)}")
+        patched += 1
+
+    print(
+        f"\n{patched} file(s) patched, {native} already tri-state, {skipped} skipped."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.speakeasy/scripts/patch_update_models.py
+++ b/.speakeasy/scripts/patch_update_models.py
@@ -142,7 +142,13 @@ def is_update_request_model(path: Path) -> bool:
 
 
 def main(argv: list[str]) -> int:
-    repo_root = Path(__file__).resolve().parents[2]
+    if len(argv) > 1:
+        # Explicit repo root from the caller. Used by CI when the script lives
+        # in a different checkout (trusted base) than the files being patched
+        # (untrusted PR head) — see `.github/workflows/patch_speakeasy_regen.yaml`.
+        repo_root = Path(argv[1]).resolve()
+    else:
+        repo_root = Path(__file__).resolve().parents[2]
     components = repo_root / "src" / "Gr4vy" / "Models" / "Components"
     if not components.is_dir():
         print(f"error: components directory not found: {components}", file=sys.stderr)

--- a/.speakeasy/scripts/patch_update_models.py
+++ b/.speakeasy/scripts/patch_update_models.py
@@ -43,6 +43,7 @@ file needs it.
 """
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -142,11 +143,25 @@ def is_update_request_model(path: Path) -> bool:
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) > 1:
-        # Explicit repo root from the caller. Used by CI when the script lives
-        # in a different checkout (trusted base) than the files being patched
-        # (untrusted PR head) — see `.github/workflows/patch_speakeasy_regen.yaml`.
-        repo_root = Path(argv[1]).resolve()
+    parser = argparse.ArgumentParser(
+        prog=Path(argv[0]).name,
+        description="Apply tri-state nullable patch to *Update.cs models.",
+    )
+    parser.add_argument(
+        "repo_root",
+        nargs="?",
+        type=Path,
+        help=(
+            "Path to the SDK repo root. Defaults to the repo containing this "
+            "script. Used by CI when the script lives in a different checkout "
+            "(trusted base) than the files being patched (untrusted PR head); "
+            "see .github/workflows/patch_speakeasy_regen.yaml."
+        ),
+    )
+    args = parser.parse_args(argv[1:])
+
+    if args.repo_root is not None:
+        repo_root = args.repo_root.resolve()
     else:
         repo_root = Path(__file__).resolve().parents[2]
     components = repo_root / "src" / "Gr4vy" / "Models" / "Components"

--- a/src/Gr4vy.Tests/BuyersUpdateIntegrationTest.cs
+++ b/src/Gr4vy.Tests/BuyersUpdateIntegrationTest.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Gr4vy;
+using Gr4vy.Models.Components;
+using NUnit.Framework;
+
+namespace Gr4vy.Tests
+{
+    /// <summary>
+    /// End-to-end tests against the e2e sandbox proving that the tri-state
+    /// nullable patch on *Update request models behaves correctly on the wire:
+    /// explicit null actually clears a field on the server, and an untouched
+    /// property leaves the existing value alone (the partial-update path).
+    /// </summary>
+    [TestFixture]
+    public class BuyersUpdateIntegrationTests
+    {
+        private Gr4vySDK _client = null!;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            var privateKey = Environment.GetEnvironmentVariable("PRIVATE_KEY");
+            if (privateKey == null)
+            {
+                privateKey = File.ReadAllText("../../../../../private_key.pem");
+            }
+
+            var bootstrap = new Gr4vySDK(
+                id: "e2e",
+                server: SDKConfig.Server.Sandbox,
+                bearerAuthSource: Auth.WithToken(privateKey)
+            );
+
+            var merchantAccountId = BitConverter
+                .ToString(RandomNumberGenerator.GetBytes(8))
+                .Replace("-", "")
+                .ToLower();
+
+            await bootstrap.MerchantAccounts.CreateAsync(
+                new MerchantAccountCreate()
+                {
+                    Id = merchantAccountId,
+                    DisplayName = merchantAccountId,
+                }
+            );
+
+            _client = new Gr4vySDK(
+                id: "e2e",
+                server: SDKConfig.Server.Sandbox,
+                bearerAuthSource: Auth.WithToken(privateKey),
+                merchantAccountId: merchantAccountId
+            );
+        }
+
+        [Test]
+        public async Task ExplicitNull_ClearsField_OnServer()
+        {
+            var created = await _client.Buyers.CreateAsync(
+                new BuyerCreate
+                {
+                    DisplayName = "Original Name",
+                    ExternalIdentifier = "ext-to-clear",
+                }
+            );
+            Assert.That(created.Id, Is.Not.Null);
+            Assert.That(created.ExternalIdentifier, Is.EqualTo("ext-to-clear"));
+
+            await _client.Buyers.UpdateAsync(
+                created.Id!,
+                new BuyerUpdate { ExternalIdentifier = null }
+            );
+
+            var fetched = await _client.Buyers.GetAsync(created.Id!);
+            Assert.That(fetched.ExternalIdentifier, Is.Null);
+            Assert.That(
+                fetched.DisplayName,
+                Is.EqualTo("Original Name"),
+                "Untouched fields must not be modified when clearing another field."
+            );
+        }
+
+        [Test]
+        public async Task UntouchedField_IsPreserved_OnServer()
+        {
+            var created = await _client.Buyers.CreateAsync(
+                new BuyerCreate
+                {
+                    DisplayName = "Original Name",
+                    ExternalIdentifier = "ext-preserve",
+                }
+            );
+            Assert.That(created.Id, Is.Not.Null);
+
+            await _client.Buyers.UpdateAsync(
+                created.Id!,
+                new BuyerUpdate { DisplayName = "Updated Name" }
+            );
+
+            var fetched = await _client.Buyers.GetAsync(created.Id!);
+            Assert.That(fetched.DisplayName, Is.EqualTo("Updated Name"));
+            Assert.That(
+                fetched.ExternalIdentifier,
+                Is.EqualTo("ext-preserve"),
+                "Properties not assigned on the update must not be sent on the wire."
+            );
+        }
+
+        [Test]
+        public async Task ExplicitValue_OverwritesField_OnServer()
+        {
+            var created = await _client.Buyers.CreateAsync(
+                new BuyerCreate
+                {
+                    DisplayName = "Original Name",
+                    ExternalIdentifier = "ext-overwrite-a",
+                }
+            );
+
+            await _client.Buyers.UpdateAsync(
+                created.Id!,
+                new BuyerUpdate { ExternalIdentifier = "ext-overwrite-b" }
+            );
+
+            var fetched = await _client.Buyers.GetAsync(created.Id!);
+            Assert.That(fetched.ExternalIdentifier, Is.EqualTo("ext-overwrite-b"));
+        }
+    }
+}

--- a/src/Gr4vy.Tests/UpdateModelSerializationTest.cs
+++ b/src/Gr4vy.Tests/UpdateModelSerializationTest.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using Gr4vy.Models.Components;
+using Gr4vy.Utils;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+[TestFixture]
+public class UpdateModelSerializationTests
+{
+    private static JObject SerializeToJObject(object value) =>
+        JObject.Parse(Utilities.SerializeJSON(value));
+
+    [Test]
+    public void BuyerUpdate_UnsetField_IsOmitted()
+    {
+        var update = new BuyerUpdate();
+        var json = SerializeToJObject(update);
+        Assert.That(json.ContainsKey("display_name"), Is.False);
+        Assert.That(json.ContainsKey("external_identifier"), Is.False);
+        Assert.That(json.ContainsKey("account_number"), Is.False);
+        Assert.That(json.ContainsKey("billing_details"), Is.False);
+    }
+
+    [Test]
+    public void BuyerUpdate_ExplicitNullString_IsSentAsNull()
+    {
+        var update = new BuyerUpdate { DisplayName = null };
+        var json = SerializeToJObject(update);
+        Assert.That(json.ContainsKey("display_name"), Is.True);
+        Assert.That(json["display_name"]!.Type, Is.EqualTo(JTokenType.Null));
+    }
+
+    [Test]
+    public void BuyerUpdate_ValueString_IsSerialized()
+    {
+        var update = new BuyerUpdate { DisplayName = "Alice" };
+        var json = SerializeToJObject(update);
+        Assert.That(json["display_name"]!.Value<string>(), Is.EqualTo("Alice"));
+    }
+
+    [Test]
+    public void BuyerUpdate_ExplicitNullObject_IsSentAsNull()
+    {
+        var update = new BuyerUpdate { BillingDetails = null };
+        var json = SerializeToJObject(update);
+        Assert.That(json.ContainsKey("billing_details"), Is.True);
+        Assert.That(json["billing_details"]!.Type, Is.EqualTo(JTokenType.Null));
+    }
+
+    [Test]
+    public void BuyerUpdate_MixedSetAndUnset_OnlyEmitsTouchedFields()
+    {
+        var update = new BuyerUpdate
+        {
+            DisplayName = "Alice",
+            ExternalIdentifier = null,
+        };
+        var json = SerializeToJObject(update);
+
+        Assert.That(json["display_name"]!.Value<string>(), Is.EqualTo("Alice"));
+        Assert.That(json.ContainsKey("external_identifier"), Is.True);
+        Assert.That(json["external_identifier"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(json.ContainsKey("account_number"), Is.False);
+        Assert.That(json.ContainsKey("billing_details"), Is.False);
+    }
+
+    [Test]
+    public void MerchantAccountUpdate_NullableLong_TriState()
+    {
+        var unset = new MerchantAccountUpdate();
+        var asNull = new MerchantAccountUpdate { OverCaptureAmount = null };
+        var asValue = new MerchantAccountUpdate { OverCaptureAmount = 1299L };
+
+        var unsetJson = SerializeToJObject(unset);
+        var nullJson = SerializeToJObject(asNull);
+        var valueJson = SerializeToJObject(asValue);
+
+        Assert.That(unsetJson.ContainsKey("over_capture_amount"), Is.False);
+        Assert.That(nullJson["over_capture_amount"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(valueJson["over_capture_amount"]!.Value<long>(), Is.EqualTo(1299L));
+    }
+
+    [Test]
+    public void MerchantAccountUpdate_NullableListString_TriState()
+    {
+        var unset = new MerchantAccountUpdate();
+        var asNull = new MerchantAccountUpdate { LoonAcceptedSchemes = null };
+        var asValue = new MerchantAccountUpdate
+        {
+            LoonAcceptedSchemes = new List<string> { "visa", "mastercard" },
+        };
+
+        Assert.That(SerializeToJObject(unset).ContainsKey("loon_accepted_schemes"), Is.False);
+        Assert.That(SerializeToJObject(asNull)["loon_accepted_schemes"]!.Type, Is.EqualTo(JTokenType.Null));
+        var arr = SerializeToJObject(asValue)["loon_accepted_schemes"]!;
+        Assert.That(arr.Type, Is.EqualTo(JTokenType.Array));
+        Assert.That(arr.ToObject<List<string>>(), Is.EqualTo(new[] { "visa", "mastercard" }));
+    }
+
+    [Test]
+    public void MerchantAccountUpdate_NonNullDefault_IsStillSerializedWhenUntouched()
+    {
+        // AccountUpdaterEnabled is generated with `= false` default; the patch
+        // preserves the pre-patch behavior of always emitting it.
+        var update = new MerchantAccountUpdate();
+        var json = SerializeToJObject(update);
+        Assert.That(json.ContainsKey("account_updater_enabled"), Is.True);
+        Assert.That(json["account_updater_enabled"]!.Value<bool>(), Is.False);
+    }
+
+    [Test]
+    public void TransactionUpdate_NullableDictionary_TriState()
+    {
+        var unset = new TransactionUpdate();
+        var asNull = new TransactionUpdate { Metadata = null };
+        var asValue = new TransactionUpdate
+        {
+            Metadata = new Dictionary<string, string> { ["k"] = "v" },
+        };
+
+        Assert.That(SerializeToJObject(unset).ContainsKey("metadata"), Is.False);
+        Assert.That(SerializeToJObject(asNull)["metadata"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(SerializeToJObject(asValue)["metadata"]!["k"]!.Value<string>(), Is.EqualTo("v"));
+    }
+
+    [Test]
+    public void ReportUpdate_NullableBool_TriState()
+    {
+        var unset = new ReportUpdate();
+        var asNull = new ReportUpdate { ScheduleEnabled = null };
+        var asTrue = new ReportUpdate { ScheduleEnabled = true };
+
+        Assert.That(SerializeToJObject(unset).ContainsKey("schedule_enabled"), Is.False);
+        Assert.That(SerializeToJObject(asNull)["schedule_enabled"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(SerializeToJObject(asTrue)["schedule_enabled"]!.Value<bool>(), Is.True);
+    }
+
+    [Test]
+    public void PaymentMethodUpdate_ClearSchemeTransactionId_SendsNull()
+    {
+        // This mirrors the documented use case where clearing
+        // scheme_transaction_id also clears scheme_transaction_id_scheme.
+        var update = new PaymentMethodUpdate { SchemeTransactionId = null };
+        var json = SerializeToJObject(update);
+        Assert.That(json["scheme_transaction_id"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(json.ContainsKey("scheme_transaction_id_scheme"), Is.False);
+    }
+}

--- a/src/Gr4vy/Models/Components/BuyerUpdate.cs
+++ b/src/Gr4vy/Models/Components/BuyerUpdate.cs
@@ -21,25 +21,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The display name for the buyer.
         /// </summary>
-        [JsonProperty("display_name")]
-        public string? DisplayName { get; set; } = null;
+        [JsonProperty("display_name", NullValueHandling = NullValueHandling.Include)]
+        public string? DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                _displayName = value;
+                _displayNameSet = true;
+            }
+        }
+
+        private string? _displayName = null;
+
+        private bool _displayNameSet = false;
+
+        public bool ShouldSerializeDisplayName() => _displayNameSet;
 
         /// <summary>
         /// The merchant identifier for this buyer.
         /// </summary>
-        [JsonProperty("external_identifier")]
-        public string? ExternalIdentifier { get; set; } = null;
+        [JsonProperty("external_identifier", NullValueHandling = NullValueHandling.Include)]
+        public string? ExternalIdentifier
+        {
+            get => _externalIdentifier;
+            set
+            {
+                _externalIdentifier = value;
+                _externalIdentifierSet = true;
+            }
+        }
+
+        private string? _externalIdentifier = null;
+
+        private bool _externalIdentifierSet = false;
+
+        public bool ShouldSerializeExternalIdentifier() => _externalIdentifierSet;
 
         /// <summary>
         /// The buyer account number.
         /// </summary>
-        [JsonProperty("account_number")]
-        public string? AccountNumber { get; set; } = null;
+        [JsonProperty("account_number", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountNumber
+        {
+            get => _accountNumber;
+            set
+            {
+                _accountNumber = value;
+                _accountNumberSet = true;
+            }
+        }
+
+        private string? _accountNumber = null;
+
+        private bool _accountNumberSet = false;
+
+        public bool ShouldSerializeAccountNumber() => _accountNumberSet;
 
         /// <summary>
         /// The billing name, address, email, and other fields for this buyer.
         /// </summary>
-        [JsonProperty("billing_details")]
-        public BillingDetails? BillingDetails { get; set; } = null;
+        [JsonProperty("billing_details", NullValueHandling = NullValueHandling.Include)]
+        public BillingDetails? BillingDetails
+        {
+            get => _billingDetails;
+            set
+            {
+                _billingDetails = value;
+                _billingDetailsSet = true;
+            }
+        }
+
+        private BillingDetails? _billingDetails = null;
+
+        private bool _billingDetailsSet = false;
+
+        public bool ShouldSerializeBillingDetails() => _billingDetailsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DigitalWalletUpdate.cs
+++ b/src/Gr4vy/Models/Components/DigitalWalletUpdate.cs
@@ -19,28 +19,140 @@ namespace Gr4vy.Models.Components
     /// </summary>
     public class DigitalWalletUpdate
     {
-        [JsonProperty("merchant_name")]
-        public string? MerchantName { get; set; } = null;
+        [JsonProperty("merchant_name", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantName
+        {
+            get => _merchantName;
+            set
+            {
+                _merchantName = value;
+                _merchantNameSet = true;
+            }
+        }
 
-        [JsonProperty("domain_names")]
-        public List<string>? DomainNames { get; set; } = null;
+        private string? _merchantName = null;
 
-        [JsonProperty("merchant_display_name")]
-        public string? MerchantDisplayName { get; set; } = null;
+        private bool _merchantNameSet = false;
 
-        [JsonProperty("merchant_url")]
-        public string? MerchantUrl { get; set; } = null;
+        public bool ShouldSerializeMerchantName() => _merchantNameSet;
 
-        [JsonProperty("merchant_country_code")]
-        public string? MerchantCountryCode { get; set; } = null;
+        [JsonProperty("domain_names", NullValueHandling = NullValueHandling.Include)]
+        public List<string>? DomainNames
+        {
+            get => _domainNames;
+            set
+            {
+                _domainNames = value;
+                _domainNamesSet = true;
+            }
+        }
 
-        [JsonProperty("merchant_category_code")]
-        public string? MerchantCategoryCode { get; set; } = null;
+        private List<string>? _domainNames = null;
 
-        [JsonProperty("address")]
-        public DigitalWalletAddress? Address { get; set; } = null;
+        private bool _domainNamesSet = false;
 
-        [JsonProperty("extra_configuration")]
-        public Dictionary<string, object>? ExtraConfiguration { get; set; } = null;
+        public bool ShouldSerializeDomainNames() => _domainNamesSet;
+
+        [JsonProperty("merchant_display_name", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantDisplayName
+        {
+            get => _merchantDisplayName;
+            set
+            {
+                _merchantDisplayName = value;
+                _merchantDisplayNameSet = true;
+            }
+        }
+
+        private string? _merchantDisplayName = null;
+
+        private bool _merchantDisplayNameSet = false;
+
+        public bool ShouldSerializeMerchantDisplayName() => _merchantDisplayNameSet;
+
+        [JsonProperty("merchant_url", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantUrl
+        {
+            get => _merchantUrl;
+            set
+            {
+                _merchantUrl = value;
+                _merchantUrlSet = true;
+            }
+        }
+
+        private string? _merchantUrl = null;
+
+        private bool _merchantUrlSet = false;
+
+        public bool ShouldSerializeMerchantUrl() => _merchantUrlSet;
+
+        [JsonProperty("merchant_country_code", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantCountryCode
+        {
+            get => _merchantCountryCode;
+            set
+            {
+                _merchantCountryCode = value;
+                _merchantCountryCodeSet = true;
+            }
+        }
+
+        private string? _merchantCountryCode = null;
+
+        private bool _merchantCountryCodeSet = false;
+
+        public bool ShouldSerializeMerchantCountryCode() => _merchantCountryCodeSet;
+
+        [JsonProperty("merchant_category_code", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantCategoryCode
+        {
+            get => _merchantCategoryCode;
+            set
+            {
+                _merchantCategoryCode = value;
+                _merchantCategoryCodeSet = true;
+            }
+        }
+
+        private string? _merchantCategoryCode = null;
+
+        private bool _merchantCategoryCodeSet = false;
+
+        public bool ShouldSerializeMerchantCategoryCode() => _merchantCategoryCodeSet;
+
+        [JsonProperty("address", NullValueHandling = NullValueHandling.Include)]
+        public DigitalWalletAddress? Address
+        {
+            get => _address;
+            set
+            {
+                _address = value;
+                _addressSet = true;
+            }
+        }
+
+        private DigitalWalletAddress? _address = null;
+
+        private bool _addressSet = false;
+
+        public bool ShouldSerializeAddress() => _addressSet;
+
+        [JsonProperty("extra_configuration", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, object>? ExtraConfiguration
+        {
+            get => _extraConfiguration;
+            set
+            {
+                _extraConfiguration = value;
+                _extraConfigurationSet = true;
+            }
+        }
+
+        private Dictionary<string, object>? _extraConfiguration = null;
+
+        private bool _extraConfigurationSet = false;
+
+        public bool ShouldSerializeExtraConfiguration() => _extraConfigurationSet;
     }
 }

--- a/src/Gr4vy/Models/Components/MerchantAccountThreeDSConfigurationUpdate.cs
+++ b/src/Gr4vy/Models/Components/MerchantAccountThreeDSConfigurationUpdate.cs
@@ -18,52 +18,178 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Acquirer BIN to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_acquirer_bin")]
-        public string? MerchantAcquirerBin { get; set; } = null;
+        [JsonProperty("merchant_acquirer_bin", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantAcquirerBin
+        {
+            get => _merchantAcquirerBin;
+            set
+            {
+                _merchantAcquirerBin = value;
+                _merchantAcquirerBinSet = true;
+            }
+        }
+
+        private string? _merchantAcquirerBin = null;
+
+        private bool _merchantAcquirerBinSet = false;
+
+        public bool ShouldSerializeMerchantAcquirerBin() => _merchantAcquirerBinSet;
 
         /// <summary>
         /// Merchant ID to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_acquirer_id")]
-        public string? MerchantAcquirerId { get; set; } = null;
+        [JsonProperty("merchant_acquirer_id", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantAcquirerId
+        {
+            get => _merchantAcquirerId;
+            set
+            {
+                _merchantAcquirerId = value;
+                _merchantAcquirerIdSet = true;
+            }
+        }
 
-        [JsonProperty("merchant_name")]
-        public string? MerchantName { get; set; } = null;
+        private string? _merchantAcquirerId = null;
+
+        private bool _merchantAcquirerIdSet = false;
+
+        public bool ShouldSerializeMerchantAcquirerId() => _merchantAcquirerIdSet;
+
+        [JsonProperty("merchant_name", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantName
+        {
+            get => _merchantName;
+            set
+            {
+                _merchantName = value;
+                _merchantNameSet = true;
+            }
+        }
+
+        private string? _merchantName = null;
+
+        private bool _merchantNameSet = false;
+
+        public bool ShouldSerializeMerchantName() => _merchantNameSet;
 
         /// <summary>
         /// The merchant's ISO 3166-1 numeric country code.
         /// </summary>
-        [JsonProperty("merchant_country_code")]
-        public string? MerchantCountryCode { get; set; } = null;
+        [JsonProperty("merchant_country_code", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantCountryCode
+        {
+            get => _merchantCountryCode;
+            set
+            {
+                _merchantCountryCode = value;
+                _merchantCountryCodeSet = true;
+            }
+        }
+
+        private string? _merchantCountryCode = null;
+
+        private bool _merchantCountryCodeSet = false;
+
+        public bool ShouldSerializeMerchantCountryCode() => _merchantCountryCodeSet;
 
         /// <summary>
         /// Merchant category code to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_category_code")]
-        public string? MerchantCategoryCode { get; set; } = null;
+        [JsonProperty("merchant_category_code", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantCategoryCode
+        {
+            get => _merchantCategoryCode;
+            set
+            {
+                _merchantCategoryCode = value;
+                _merchantCategoryCodeSet = true;
+            }
+        }
+
+        private string? _merchantCategoryCode = null;
+
+        private bool _merchantCategoryCodeSet = false;
+
+        public bool ShouldSerializeMerchantCategoryCode() => _merchantCategoryCodeSet;
 
         /// <summary>
         /// URL to send when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_url")]
-        public string? MerchantUrl { get; set; } = null;
+        [JsonProperty("merchant_url", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantUrl
+        {
+            get => _merchantUrl;
+            set
+            {
+                _merchantUrl = value;
+                _merchantUrlSet = true;
+            }
+        }
+
+        private string? _merchantUrl = null;
+
+        private bool _merchantUrlSet = false;
+
+        public bool ShouldSerializeMerchantUrl() => _merchantUrlSet;
 
         /// <summary>
         /// The card scheme for this 3DS configuration.
         /// </summary>
-        [JsonProperty("scheme")]
-        public string? Scheme { get; set; } = null;
+        [JsonProperty("scheme", NullValueHandling = NullValueHandling.Include)]
+        public string? Scheme
+        {
+            get => _scheme;
+            set
+            {
+                _scheme = value;
+                _schemeSet = true;
+            }
+        }
+
+        private string? _scheme = null;
+
+        private bool _schemeSet = false;
+
+        public bool ShouldSerializeScheme() => _schemeSet;
 
         /// <summary>
         /// ISO 4217 currency code (3 characters). If left null, the configuration will apply to all currencies.
         /// </summary>
-        [JsonProperty("currency")]
-        public string? Currency { get; set; } = null;
+        [JsonProperty("currency", NullValueHandling = NullValueHandling.Include)]
+        public string? Currency
+        {
+            get => _currency;
+            set
+            {
+                _currency = value;
+                _currencySet = true;
+            }
+        }
+
+        private string? _currency = null;
+
+        private bool _currencySet = false;
+
+        public bool ShouldSerializeCurrency() => _currencySet;
 
         /// <summary>
         /// Any additional information about the 3DS configuration that you would like to store as key-value pairs.
         /// </summary>
-        [JsonProperty("metadata")]
-        public Dictionary<string, string>? Metadata { get; set; } = null;
+        [JsonProperty("metadata", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? Metadata
+        {
+            get => _metadata;
+            set
+            {
+                _metadata = value;
+                _metadataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _metadata = null;
+
+        private bool _metadataSet = false;
+
+        public bool ShouldSerializeMetadata() => _metadataSet;
     }
 }

--- a/src/Gr4vy/Models/Components/MerchantAccountUpdate.cs
+++ b/src/Gr4vy/Models/Components/MerchantAccountUpdate.cs
@@ -18,109 +18,361 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Whether the Real-Time Account Updater service is enabled for this merchant account. The Account Updater service is used to update card details when cards are lost, stolen or expired. If the field is not set or if it's set to `false`, the Account Updater service doesn't get called if a payment fails with expired or invalid card details. If the field is set to `true`, the service is called. Please note that for this to work the other `account_updater_* fields` must be set as well.
         /// </summary>
-        [JsonProperty("account_updater_enabled")]
-        public bool? AccountUpdaterEnabled { get; set; } = false;
+        [JsonProperty("account_updater_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? AccountUpdaterEnabled
+        {
+            get => _accountUpdaterEnabled;
+            set
+            {
+                _accountUpdaterEnabled = value;
+                _accountUpdaterEnabledSet = true;
+            }
+        }
+
+        private bool? _accountUpdaterEnabled = false;
+
+        private bool _accountUpdaterEnabledSet = true;
+
+        public bool ShouldSerializeAccountUpdaterEnabled() => _accountUpdaterEnabledSet;
 
         /// <summary>
         /// The public key used to encrypt the request to the Real-Time Account Updater service. The Account Updater service is used to update card details when cards are lost, stolen or expired. If the field is not set or if it's set to `null`, the Account Updater service doesn't get called. If the field is set, the other `account_updater_*` fields must be set as well.
         /// </summary>
-        [JsonProperty("account_updater_request_encryption_key")]
-        public string? AccountUpdaterRequestEncryptionKey { get; set; } = null;
+        [JsonProperty("account_updater_request_encryption_key", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountUpdaterRequestEncryptionKey
+        {
+            get => _accountUpdaterRequestEncryptionKey;
+            set
+            {
+                _accountUpdaterRequestEncryptionKey = value;
+                _accountUpdaterRequestEncryptionKeySet = true;
+            }
+        }
+
+        private string? _accountUpdaterRequestEncryptionKey = null;
+
+        private bool _accountUpdaterRequestEncryptionKeySet = false;
+
+        public bool ShouldSerializeAccountUpdaterRequestEncryptionKey() => _accountUpdaterRequestEncryptionKeySet;
 
         /// <summary>
         /// The ID of the key used to encrypt the request to the Real-Time Account Updater service. The Account Updater service is used to update card details when cards are lost, stolen or expired. If the field is not set or if it's set to `null`, the Account Updater service doesn't get called. If the field is set, the other `account_updater_*` fields must be set as well.
         /// </summary>
-        [JsonProperty("account_updater_request_encryption_key_id")]
-        public string? AccountUpdaterRequestEncryptionKeyId { get; set; } = null;
+        [JsonProperty("account_updater_request_encryption_key_id", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountUpdaterRequestEncryptionKeyId
+        {
+            get => _accountUpdaterRequestEncryptionKeyId;
+            set
+            {
+                _accountUpdaterRequestEncryptionKeyId = value;
+                _accountUpdaterRequestEncryptionKeyIdSet = true;
+            }
+        }
+
+        private string? _accountUpdaterRequestEncryptionKeyId = null;
+
+        private bool _accountUpdaterRequestEncryptionKeyIdSet = false;
+
+        public bool ShouldSerializeAccountUpdaterRequestEncryptionKeyId() => _accountUpdaterRequestEncryptionKeyIdSet;
 
         /// <summary>
         /// The key used to decrypt the response from the Real-Time Account Updater service. The Account Updater service is used to update card details when cards are lost, stolen or expired. If the field is not set or if it's set to `null`, the Account Updater service doesn't get called. If the field is set, the other `account_updater_*` fields must be set as well.
         /// </summary>
-        [JsonProperty("account_updater_response_decryption_key")]
-        public string? AccountUpdaterResponseDecryptionKey { get; set; } = null;
+        [JsonProperty("account_updater_response_decryption_key", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountUpdaterResponseDecryptionKey
+        {
+            get => _accountUpdaterResponseDecryptionKey;
+            set
+            {
+                _accountUpdaterResponseDecryptionKey = value;
+                _accountUpdaterResponseDecryptionKeySet = true;
+            }
+        }
+
+        private string? _accountUpdaterResponseDecryptionKey = null;
+
+        private bool _accountUpdaterResponseDecryptionKeySet = false;
+
+        public bool ShouldSerializeAccountUpdaterResponseDecryptionKey() => _accountUpdaterResponseDecryptionKeySet;
 
         /// <summary>
         /// The ID of the key used to decrypt the request from the Real-Time Account Updater service. The Account Updater service is used to update card details when cards are lost, stolen or expired. If the field is not set or if it's set to `null`, the Account Updater service doesn't get called. If the field is set, the other `account_updater_*` fields must be set as well.
         /// </summary>
-        [JsonProperty("account_updater_response_decryption_key_id")]
-        public string? AccountUpdaterResponseDecryptionKeyId { get; set; } = null;
+        [JsonProperty("account_updater_response_decryption_key_id", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountUpdaterResponseDecryptionKeyId
+        {
+            get => _accountUpdaterResponseDecryptionKeyId;
+            set
+            {
+                _accountUpdaterResponseDecryptionKeyId = value;
+                _accountUpdaterResponseDecryptionKeyIdSet = true;
+            }
+        }
+
+        private string? _accountUpdaterResponseDecryptionKeyId = null;
+
+        private bool _accountUpdaterResponseDecryptionKeyIdSet = false;
+
+        public bool ShouldSerializeAccountUpdaterResponseDecryptionKeyId() => _accountUpdaterResponseDecryptionKeyIdSet;
 
         /// <summary>
         /// The maximum monetary amount allowed for over-capture, in the smallest currency unit, for example `1299` cents to allow for an over-capture of `$12.99`.
         /// </summary>
-        [JsonProperty("over_capture_amount")]
-        public long? OverCaptureAmount { get; set; } = null;
+        [JsonProperty("over_capture_amount", NullValueHandling = NullValueHandling.Include)]
+        public long? OverCaptureAmount
+        {
+            get => _overCaptureAmount;
+            set
+            {
+                _overCaptureAmount = value;
+                _overCaptureAmountSet = true;
+            }
+        }
+
+        private long? _overCaptureAmount = null;
+
+        private bool _overCaptureAmountSet = false;
+
+        public bool ShouldSerializeOverCaptureAmount() => _overCaptureAmountSet;
 
         /// <summary>
         /// The maximum percentage allowed for over-capture, for example `25` to allow for an over-capture of `25%` of the original transaction amount.
         /// </summary>
-        [JsonProperty("over_capture_percentage")]
-        public long? OverCapturePercentage { get; set; } = null;
+        [JsonProperty("over_capture_percentage", NullValueHandling = NullValueHandling.Include)]
+        public long? OverCapturePercentage
+        {
+            get => _overCapturePercentage;
+            set
+            {
+                _overCapturePercentage = value;
+                _overCapturePercentageSet = true;
+            }
+        }
+
+        private long? _overCapturePercentage = null;
+
+        private bool _overCapturePercentageSet = false;
+
+        public bool ShouldSerializeOverCapturePercentage() => _overCapturePercentageSet;
 
         /// <summary>
         /// Client key provided by Pagos to authenticate to the Loon API. Loon is the Account Updater service we use and if the field is not set or if it's set to null, the Account Updater service doesn't get configured. If the field is set to `null`, the other `loon_*` fields must be set to null as well.
         /// </summary>
-        [JsonProperty("loon_client_key")]
-        public string? LoonClientKey { get; set; } = null;
+        [JsonProperty("loon_client_key", NullValueHandling = NullValueHandling.Include)]
+        public string? LoonClientKey
+        {
+            get => _loonClientKey;
+            set
+            {
+                _loonClientKey = value;
+                _loonClientKeySet = true;
+            }
+        }
+
+        private string? _loonClientKey = null;
+
+        private bool _loonClientKeySet = false;
+
+        public bool ShouldSerializeLoonClientKey() => _loonClientKeySet;
 
         /// <summary>
         /// Secret key provided by Pagos to authenticate to the Loon API. Loon is the Account Updater service we use and if the field is not set or if it's set to null, the Account Updater service doesn't get configured. If the field is set to `null`, the other `loon_*` fields must be set to null as well.
         /// </summary>
-        [JsonProperty("loon_secret_key")]
-        public string? LoonSecretKey { get; set; } = null;
+        [JsonProperty("loon_secret_key", NullValueHandling = NullValueHandling.Include)]
+        public string? LoonSecretKey
+        {
+            get => _loonSecretKey;
+            set
+            {
+                _loonSecretKey = value;
+                _loonSecretKeySet = true;
+            }
+        }
+
+        private string? _loonSecretKey = null;
+
+        private bool _loonSecretKeySet = false;
+
+        public bool ShouldSerializeLoonSecretKey() => _loonSecretKeySet;
 
         /// <summary>
         /// Card schemes accepted when creating jobs using this set of Loon API keys. Loon is the Account Updater service we use and if the field is not set or if it's set to null, the Account Updater service doesn't get configured. If the field is set to `null`, the other `loon_*` fields must be set to null as well.
         /// </summary>
-        [JsonProperty("loon_accepted_schemes")]
-        public List<string>? LoonAcceptedSchemes { get; set; } = null;
+        [JsonProperty("loon_accepted_schemes", NullValueHandling = NullValueHandling.Include)]
+        public List<string>? LoonAcceptedSchemes
+        {
+            get => _loonAcceptedSchemes;
+            set
+            {
+                _loonAcceptedSchemes = value;
+                _loonAcceptedSchemesSet = true;
+            }
+        }
+
+        private List<string>? _loonAcceptedSchemes = null;
+
+        private bool _loonAcceptedSchemesSet = false;
+
+        public bool ShouldSerializeLoonAcceptedSchemes() => _loonAcceptedSchemesSet;
 
         /// <summary>
         /// Requestor ID provided for Visa after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("visa_network_tokens_requestor_id")]
-        public string? VisaNetworkTokensRequestorId { get; set; } = null;
+        [JsonProperty("visa_network_tokens_requestor_id", NullValueHandling = NullValueHandling.Include)]
+        public string? VisaNetworkTokensRequestorId
+        {
+            get => _visaNetworkTokensRequestorId;
+            set
+            {
+                _visaNetworkTokensRequestorId = value;
+                _visaNetworkTokensRequestorIdSet = true;
+            }
+        }
+
+        private string? _visaNetworkTokensRequestorId = null;
+
+        private bool _visaNetworkTokensRequestorIdSet = false;
+
+        public bool ShouldSerializeVisaNetworkTokensRequestorId() => _visaNetworkTokensRequestorIdSet;
 
         /// <summary>
         /// Application ID provided for Visa after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("visa_network_tokens_app_id")]
-        public string? VisaNetworkTokensAppId { get; set; } = null;
+        [JsonProperty("visa_network_tokens_app_id", NullValueHandling = NullValueHandling.Include)]
+        public string? VisaNetworkTokensAppId
+        {
+            get => _visaNetworkTokensAppId;
+            set
+            {
+                _visaNetworkTokensAppId = value;
+                _visaNetworkTokensAppIdSet = true;
+            }
+        }
+
+        private string? _visaNetworkTokensAppId = null;
+
+        private bool _visaNetworkTokensAppIdSet = false;
+
+        public bool ShouldSerializeVisaNetworkTokensAppId() => _visaNetworkTokensAppIdSet;
 
         /// <summary>
         /// Requestor ID provided for American Express after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("amex_network_tokens_requestor_id")]
-        public string? AmexNetworkTokensRequestorId { get; set; } = null;
+        [JsonProperty("amex_network_tokens_requestor_id", NullValueHandling = NullValueHandling.Include)]
+        public string? AmexNetworkTokensRequestorId
+        {
+            get => _amexNetworkTokensRequestorId;
+            set
+            {
+                _amexNetworkTokensRequestorId = value;
+                _amexNetworkTokensRequestorIdSet = true;
+            }
+        }
+
+        private string? _amexNetworkTokensRequestorId = null;
+
+        private bool _amexNetworkTokensRequestorIdSet = false;
+
+        public bool ShouldSerializeAmexNetworkTokensRequestorId() => _amexNetworkTokensRequestorIdSet;
 
         /// <summary>
         /// Application ID provided for American Express after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("amex_network_tokens_app_id")]
-        public string? AmexNetworkTokensAppId { get; set; } = null;
+        [JsonProperty("amex_network_tokens_app_id", NullValueHandling = NullValueHandling.Include)]
+        public string? AmexNetworkTokensAppId
+        {
+            get => _amexNetworkTokensAppId;
+            set
+            {
+                _amexNetworkTokensAppId = value;
+                _amexNetworkTokensAppIdSet = true;
+            }
+        }
+
+        private string? _amexNetworkTokensAppId = null;
+
+        private bool _amexNetworkTokensAppIdSet = false;
+
+        public bool ShouldSerializeAmexNetworkTokensAppId() => _amexNetworkTokensAppIdSet;
 
         /// <summary>
         /// Requestor ID provided for Mastercard after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("mastercard_network_tokens_requestor_id")]
-        public string? MastercardNetworkTokensRequestorId { get; set; } = null;
+        [JsonProperty("mastercard_network_tokens_requestor_id", NullValueHandling = NullValueHandling.Include)]
+        public string? MastercardNetworkTokensRequestorId
+        {
+            get => _mastercardNetworkTokensRequestorId;
+            set
+            {
+                _mastercardNetworkTokensRequestorId = value;
+                _mastercardNetworkTokensRequestorIdSet = true;
+            }
+        }
+
+        private string? _mastercardNetworkTokensRequestorId = null;
+
+        private bool _mastercardNetworkTokensRequestorIdSet = false;
+
+        public bool ShouldSerializeMastercardNetworkTokensRequestorId() => _mastercardNetworkTokensRequestorIdSet;
 
         /// <summary>
         /// Application ID provided for Mastercard after onboarding to use Network Tokens.
         /// </summary>
-        [JsonProperty("mastercard_network_tokens_app_id")]
-        public string? MastercardNetworkTokensAppId { get; set; } = null;
+        [JsonProperty("mastercard_network_tokens_app_id", NullValueHandling = NullValueHandling.Include)]
+        public string? MastercardNetworkTokensAppId
+        {
+            get => _mastercardNetworkTokensAppId;
+            set
+            {
+                _mastercardNetworkTokensAppId = value;
+                _mastercardNetworkTokensAppIdSet = true;
+            }
+        }
+
+        private string? _mastercardNetworkTokensAppId = null;
+
+        private bool _mastercardNetworkTokensAppIdSet = false;
+
+        public bool ShouldSerializeMastercardNetworkTokensAppId() => _mastercardNetworkTokensAppIdSet;
 
         /// <summary>
         /// When enabled network tokens will be generated asynchronously and only used on subsequent transactions to speed up transaction processing.
         /// </summary>
-        [JsonProperty("async_network_tokens_enabled")]
-        public bool? AsyncNetworkTokensEnabled { get; set; } = false;
+        [JsonProperty("async_network_tokens_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? AsyncNetworkTokensEnabled
+        {
+            get => _asyncNetworkTokensEnabled;
+            set
+            {
+                _asyncNetworkTokensEnabled = value;
+                _asyncNetworkTokensEnabledSet = true;
+            }
+        }
+
+        private bool? _asyncNetworkTokensEnabled = false;
+
+        private bool _asyncNetworkTokensEnabledSet = true;
+
+        public bool ShouldSerializeAsyncNetworkTokensEnabled() => _asyncNetworkTokensEnabledSet;
 
         /// <summary>
         /// The display name for the merchant account.
         /// </summary>
-        [JsonProperty("display_name")]
-        public string? DisplayName { get; set; } = null;
+        [JsonProperty("display_name", NullValueHandling = NullValueHandling.Include)]
+        public string? DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                _displayName = value;
+                _displayNameSet = true;
+            }
+        }
+
+        private string? _displayName = null;
+
+        private bool _displayNameSet = false;
+
+        public bool ShouldSerializeDisplayName() => _displayNameSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaymentMethodUpdate.cs
+++ b/src/Gr4vy/Models/Components/PaymentMethodUpdate.cs
@@ -20,25 +20,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The new expiration date for the payment method.
         /// </summary>
-        [JsonProperty("expiration_date")]
-        public string? ExpirationDate { get; set; } = null;
+        [JsonProperty("expiration_date", NullValueHandling = NullValueHandling.Include)]
+        public string? ExpirationDate
+        {
+            get => _expirationDate;
+            set
+            {
+                _expirationDate = value;
+                _expirationDateSet = true;
+            }
+        }
+
+        private string? _expirationDate = null;
+
+        private bool _expirationDateSet = false;
+
+        public bool ShouldSerializeExpirationDate() => _expirationDateSet;
 
         /// <summary>
         /// A scheme transaction identifier to associate with this payment method. Explicitly setting this field to `null` will also clear `scheme_transaction_id_scheme` as a side-effect. When setting a new value and `scheme_transaction_id_scheme` is both omitted from the payload and previously unset,`scheme_transaction_id_scheme` will be populated from the payment method's existing `scheme`.
         /// </summary>
-        [JsonProperty("scheme_transaction_id")]
-        public string? SchemeTransactionId { get; set; } = null;
+        [JsonProperty("scheme_transaction_id", NullValueHandling = NullValueHandling.Include)]
+        public string? SchemeTransactionId
+        {
+            get => _schemeTransactionId;
+            set
+            {
+                _schemeTransactionId = value;
+                _schemeTransactionIdSet = true;
+            }
+        }
+
+        private string? _schemeTransactionId = null;
+
+        private bool _schemeTransactionIdSet = false;
+
+        public bool ShouldSerializeSchemeTransactionId() => _schemeTransactionIdSet;
 
         /// <summary>
         /// The scheme associated with `scheme_transaction_id`. Only applies to card payments. When setting a new value for `scheme_transaction_id`, if `scheme_transaction_id_scheme`is both omitted from the payload and previously unset, `scheme_transaction_id_scheme` will be populated from the payment method's existing `scheme`.
         /// </summary>
-        [JsonProperty("scheme_transaction_id_scheme")]
-        public string? SchemeTransactionIdScheme { get; set; } = null;
+        [JsonProperty("scheme_transaction_id_scheme", NullValueHandling = NullValueHandling.Include)]
+        public string? SchemeTransactionIdScheme
+        {
+            get => _schemeTransactionIdScheme;
+            set
+            {
+                _schemeTransactionIdScheme = value;
+                _schemeTransactionIdSchemeSet = true;
+            }
+        }
+
+        private string? _schemeTransactionIdScheme = null;
+
+        private bool _schemeTransactionIdSchemeSet = false;
+
+        public bool ShouldSerializeSchemeTransactionIdScheme() => _schemeTransactionIdSchemeSet;
 
         /// <summary>
         /// A transaction link identifier to associate with this payment method.
         /// </summary>
-        [JsonProperty("transaction_link_id")]
-        public string? TransactionLinkId { get; set; } = null;
+        [JsonProperty("transaction_link_id", NullValueHandling = NullValueHandling.Include)]
+        public string? TransactionLinkId
+        {
+            get => _transactionLinkId;
+            set
+            {
+                _transactionLinkId = value;
+                _transactionLinkIdSet = true;
+            }
+        }
+
+        private string? _transactionLinkId = null;
+
+        private bool _transactionLinkIdSet = false;
+
+        public bool ShouldSerializeTransactionLinkId() => _transactionLinkIdSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaymentServiceUpdate.cs
+++ b/src/Gr4vy/Models/Components/PaymentServiceUpdate.cs
@@ -22,79 +22,261 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The display name for the payment service.
         /// </summary>
-        [JsonProperty("display_name")]
-        public string? DisplayName { get; set; } = null;
+        [JsonProperty("display_name", NullValueHandling = NullValueHandling.Include)]
+        public string? DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                _displayName = value;
+                _displayNameSet = true;
+            }
+        }
+
+        private string? _displayName = null;
+
+        private bool _displayNameSet = false;
+
+        public bool ShouldSerializeDisplayName() => _displayNameSet;
 
         /// <summary>
         /// The non-secret credential fields that have been configured for this payment service. Any secret fields are omitted.
         /// </summary>
-        [JsonProperty("fields")]
-        public List<VoidableField>? Fields { get; set; } = null;
+        [JsonProperty("fields", NullValueHandling = NullValueHandling.Include)]
+        public List<VoidableField>? Fields
+        {
+            get => _fields;
+            set
+            {
+                _fields = value;
+                _fieldsSet = true;
+            }
+        }
+
+        private List<VoidableField>? _fields = null;
+
+        private bool _fieldsSet = false;
+
+        public bool ShouldSerializeFields() => _fieldsSet;
 
         /// <summary>
         /// The non-secret reporting fields that have been configured for this payment service. Any secret fields are omitted.
         /// </summary>
-        [JsonProperty("reporting_fields")]
-        public List<VoidableField>? ReportingFields { get; set; } = null;
+        [JsonProperty("reporting_fields", NullValueHandling = NullValueHandling.Include)]
+        public List<VoidableField>? ReportingFields
+        {
+            get => _reportingFields;
+            set
+            {
+                _reportingFields = value;
+                _reportingFieldsSet = true;
+            }
+        }
+
+        private List<VoidableField>? _reportingFields = null;
+
+        private bool _reportingFieldsSet = false;
+
+        public bool ShouldSerializeReportingFields() => _reportingFieldsSet;
 
         /// <summary>
         /// Deprecated field used to define the order in which to process payment services.
         /// </summary>
-        [JsonProperty("position")]
-        public long? Position { get; set; } = null;
+        [JsonProperty("position", NullValueHandling = NullValueHandling.Include)]
+        public long? Position
+        {
+            get => _position;
+            set
+            {
+                _position = value;
+                _positionSet = true;
+            }
+        }
+
+        private long? _position = null;
+
+        private bool _positionSet = false;
+
+        public bool ShouldSerializePosition() => _positionSet;
 
         /// <summary>
         /// A list of currencies for which this service is enabled, in ISO 4217 three-letter code format.
         /// </summary>
-        [JsonProperty("accepted_currencies")]
-        public List<string>? AcceptedCurrencies { get; set; } = null;
+        [JsonProperty("accepted_currencies", NullValueHandling = NullValueHandling.Include)]
+        public List<string>? AcceptedCurrencies
+        {
+            get => _acceptedCurrencies;
+            set
+            {
+                _acceptedCurrencies = value;
+                _acceptedCurrenciesSet = true;
+            }
+        }
+
+        private List<string>? _acceptedCurrencies = null;
+
+        private bool _acceptedCurrenciesSet = false;
+
+        public bool ShouldSerializeAcceptedCurrencies() => _acceptedCurrenciesSet;
 
         /// <summary>
         /// A list of countries for which this service is enabled, in ISO two-letter code format.
         /// </summary>
-        [JsonProperty("accepted_countries")]
-        public List<string>? AcceptedCountries { get; set; } = null;
+        [JsonProperty("accepted_countries", NullValueHandling = NullValueHandling.Include)]
+        public List<string>? AcceptedCountries
+        {
+            get => _acceptedCountries;
+            set
+            {
+                _acceptedCountries = value;
+                _acceptedCountriesSet = true;
+            }
+        }
+
+        private List<string>? _acceptedCountries = null;
+
+        private bool _acceptedCountriesSet = false;
+
+        public bool ShouldSerializeAcceptedCountries() => _acceptedCountriesSet;
 
         /// <summary>
         /// Defines if this payment service is currently active.
         /// </summary>
-        [JsonProperty("active")]
-        public bool? Active { get; set; } = null;
+        [JsonProperty("active", NullValueHandling = NullValueHandling.Include)]
+        public bool? Active
+        {
+            get => _active;
+            set
+            {
+                _active = value;
+                _activeSet = true;
+            }
+        }
+
+        private bool? _active = null;
+
+        private bool _activeSet = false;
+
+        public bool ShouldSerializeActive() => _activeSet;
 
         /// <summary>
         /// Defines if this payment service has 3DS enabled.
         /// </summary>
-        [JsonProperty("three_d_secure_enabled")]
-        public bool? ThreeDSecureEnabled { get; set; } = null;
+        [JsonProperty("three_d_secure_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? ThreeDSecureEnabled
+        {
+            get => _threeDSecureEnabled;
+            set
+            {
+                _threeDSecureEnabled = value;
+                _threeDSecureEnabledSet = true;
+            }
+        }
+
+        private bool? _threeDSecureEnabled = null;
+
+        private bool _threeDSecureEnabledSet = false;
+
+        public bool ShouldSerializeThreeDSecureEnabled() => _threeDSecureEnabledSet;
 
         /// <summary>
         /// An object containing a key for each supported card schemes, and for each key an object with the 3DS profile for this service for that scheme.
         /// </summary>
-        [JsonProperty("merchant_profile")]
-        public Dictionary<string, MerchantProfileScheme?>? MerchantProfile { get; set; } = null;
+        [JsonProperty("merchant_profile", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, MerchantProfileScheme?>? MerchantProfile
+        {
+            get => _merchantProfile;
+            set
+            {
+                _merchantProfile = value;
+                _merchantProfileSet = true;
+            }
+        }
+
+        private Dictionary<string, MerchantProfileScheme?>? _merchantProfile = null;
+
+        private bool _merchantProfileSet = false;
+
+        public bool ShouldSerializeMerchantProfile() => _merchantProfileSet;
 
         /// <summary>
         /// Defines if this payment service support payment method tokenization.
         /// </summary>
-        [JsonProperty("payment_method_tokenization_enabled")]
-        public bool? PaymentMethodTokenizationEnabled { get; set; } = null;
+        [JsonProperty("payment_method_tokenization_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? PaymentMethodTokenizationEnabled
+        {
+            get => _paymentMethodTokenizationEnabled;
+            set
+            {
+                _paymentMethodTokenizationEnabled = value;
+                _paymentMethodTokenizationEnabledSet = true;
+            }
+        }
+
+        private bool? _paymentMethodTokenizationEnabled = null;
+
+        private bool _paymentMethodTokenizationEnabledSet = false;
+
+        public bool ShouldSerializePaymentMethodTokenizationEnabled() => _paymentMethodTokenizationEnabledSet;
 
         /// <summary>
         /// Defines if this payment service supports network tokens.
         /// </summary>
-        [JsonProperty("network_tokens_enabled")]
-        public bool? NetworkTokensEnabled { get; set; } = null;
+        [JsonProperty("network_tokens_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? NetworkTokensEnabled
+        {
+            get => _networkTokensEnabled;
+            set
+            {
+                _networkTokensEnabled = value;
+                _networkTokensEnabledSet = true;
+            }
+        }
+
+        private bool? _networkTokensEnabled = null;
+
+        private bool _networkTokensEnabledSet = false;
+
+        public bool ShouldSerializeNetworkTokensEnabled() => _networkTokensEnabledSet;
 
         /// <summary>
         /// Defines if this payment service is open loop.
         /// </summary>
-        [JsonProperty("open_loop")]
-        public bool? OpenLoop { get; set; } = null;
+        [JsonProperty("open_loop", NullValueHandling = NullValueHandling.Include)]
+        public bool? OpenLoop
+        {
+            get => _openLoop;
+            set
+            {
+                _openLoop = value;
+                _openLoopSet = true;
+            }
+        }
+
+        private bool? _openLoop = null;
+
+        private bool _openLoopSet = false;
+
+        public bool ShouldSerializeOpenLoop() => _openLoopSet;
 
         /// <summary>
         /// Defines if this payment service has settlement reporting enabled.
         /// </summary>
-        [JsonProperty("settlement_reporting_enabled")]
-        public bool? SettlementReportingEnabled { get; set; } = false;
+        [JsonProperty("settlement_reporting_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? SettlementReportingEnabled
+        {
+            get => _settlementReportingEnabled;
+            set
+            {
+                _settlementReportingEnabled = value;
+                _settlementReportingEnabledSet = true;
+            }
+        }
+
+        private bool? _settlementReportingEnabled = false;
+
+        private bool _settlementReportingEnabledSet = true;
+
+        public bool ShouldSerializeSettlementReportingEnabled() => _settlementReportingEnabledSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ReportUpdate.cs
+++ b/src/Gr4vy/Models/Components/ReportUpdate.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The name of the report.
         /// </summary>
-        [JsonProperty("name")]
-        public string? Name { get; set; } = null;
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Include)]
+        public string? Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                _nameSet = true;
+            }
+        }
+
+        private string? _name = null;
+
+        private bool _nameSet = false;
+
+        public bool ShouldSerializeName() => _nameSet;
 
         /// <summary>
         /// A description of the report.
         /// </summary>
-        [JsonProperty("description")]
-        public string? Description { get; set; } = null;
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Include)]
+        public string? Description
+        {
+            get => _description;
+            set
+            {
+                _description = value;
+                _descriptionSet = true;
+            }
+        }
+
+        private string? _description = null;
+
+        private bool _descriptionSet = false;
+
+        public bool ShouldSerializeDescription() => _descriptionSet;
 
         /// <summary>
         /// Whether the report schedule is enabled.
         /// </summary>
-        [JsonProperty("schedule_enabled")]
-        public bool? ScheduleEnabled { get; set; } = null;
+        [JsonProperty("schedule_enabled", NullValueHandling = NullValueHandling.Include)]
+        public bool? ScheduleEnabled
+        {
+            get => _scheduleEnabled;
+            set
+            {
+                _scheduleEnabled = value;
+                _scheduleEnabledSet = true;
+            }
+        }
+
+        private bool? _scheduleEnabled = null;
+
+        private bool _scheduleEnabledSet = false;
+
+        public bool ShouldSerializeScheduleEnabled() => _scheduleEnabledSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ShippingDetailsUpdate.cs
+++ b/src/Gr4vy/Models/Components/ShippingDetailsUpdate.cs
@@ -18,31 +18,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The first name(s) or given name for the buyer.
         /// </summary>
-        [JsonProperty("first_name")]
-        public string? FirstName { get; set; } = null;
+        [JsonProperty("first_name", NullValueHandling = NullValueHandling.Include)]
+        public string? FirstName
+        {
+            get => _firstName;
+            set
+            {
+                _firstName = value;
+                _firstNameSet = true;
+            }
+        }
+
+        private string? _firstName = null;
+
+        private bool _firstNameSet = false;
+
+        public bool ShouldSerializeFirstName() => _firstNameSet;
 
         /// <summary>
         /// The last name, or family name, of the buyer.
         /// </summary>
-        [JsonProperty("last_name")]
-        public string? LastName { get; set; } = null;
+        [JsonProperty("last_name", NullValueHandling = NullValueHandling.Include)]
+        public string? LastName
+        {
+            get => _lastName;
+            set
+            {
+                _lastName = value;
+                _lastNameSet = true;
+            }
+        }
+
+        private string? _lastName = null;
+
+        private bool _lastNameSet = false;
+
+        public bool ShouldSerializeLastName() => _lastNameSet;
 
         /// <summary>
         /// The email address for the buyer.
         /// </summary>
-        [JsonProperty("email_address")]
-        public string? EmailAddress { get; set; } = null;
+        [JsonProperty("email_address", NullValueHandling = NullValueHandling.Include)]
+        public string? EmailAddress
+        {
+            get => _emailAddress;
+            set
+            {
+                _emailAddress = value;
+                _emailAddressSet = true;
+            }
+        }
+
+        private string? _emailAddress = null;
+
+        private bool _emailAddressSet = false;
+
+        public bool ShouldSerializeEmailAddress() => _emailAddressSet;
 
         /// <summary>
         /// The phone number for the buyer which should be formatted according to the E164 number standard.
         /// </summary>
-        [JsonProperty("phone_number")]
-        public string? PhoneNumber { get; set; } = null;
+        [JsonProperty("phone_number", NullValueHandling = NullValueHandling.Include)]
+        public string? PhoneNumber
+        {
+            get => _phoneNumber;
+            set
+            {
+                _phoneNumber = value;
+                _phoneNumberSet = true;
+            }
+        }
+
+        private string? _phoneNumber = null;
+
+        private bool _phoneNumberSet = false;
+
+        public bool ShouldSerializePhoneNumber() => _phoneNumberSet;
 
         /// <summary>
         /// The billing address for the buyer.
         /// </summary>
-        [JsonProperty("address")]
-        public Address? Address { get; set; } = null;
+        [JsonProperty("address", NullValueHandling = NullValueHandling.Include)]
+        public Address? Address
+        {
+            get => _address;
+            set
+            {
+                _address = value;
+                _addressSet = true;
+            }
+        }
+
+        private Address? _address = null;
+
+        private bool _addressSet = false;
+
+        public bool ShouldSerializeAddress() => _addressSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ThreeDSecureScenarioUpdate.cs
+++ b/src/Gr4vy/Models/Components/ThreeDSecureScenarioUpdate.cs
@@ -18,13 +18,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Conditions for the scenario.
         /// </summary>
-        [JsonProperty("conditions")]
-        public ThreeDSecureScenarioConditions? Conditions { get; set; } = null;
+        [JsonProperty("conditions", NullValueHandling = NullValueHandling.Include)]
+        public ThreeDSecureScenarioConditions? Conditions
+        {
+            get => _conditions;
+            set
+            {
+                _conditions = value;
+                _conditionsSet = true;
+            }
+        }
+
+        private ThreeDSecureScenarioConditions? _conditions = null;
+
+        private bool _conditionsSet = false;
+
+        public bool ShouldSerializeConditions() => _conditionsSet;
 
         /// <summary>
         /// Outcome for the scenario.
         /// </summary>
-        [JsonProperty("outcome")]
-        public ThreeDSecureScenarioOutcome? Outcome { get; set; } = null;
+        [JsonProperty("outcome", NullValueHandling = NullValueHandling.Include)]
+        public ThreeDSecureScenarioOutcome? Outcome
+        {
+            get => _outcome;
+            set
+            {
+                _outcome = value;
+                _outcomeSet = true;
+            }
+        }
+
+        private ThreeDSecureScenarioOutcome? _outcome = null;
+
+        private bool _outcomeSet = false;
+
+        public bool ShouldSerializeOutcome() => _outcomeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TransactionUpdate.cs
+++ b/src/Gr4vy/Models/Components/TransactionUpdate.cs
@@ -19,19 +19,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// An external identifier that can be used to match the transaction against your own records.
         /// </summary>
-        [JsonProperty("external_identifier")]
-        public string? ExternalIdentifier { get; set; } = null;
+        [JsonProperty("external_identifier", NullValueHandling = NullValueHandling.Include)]
+        public string? ExternalIdentifier
+        {
+            get => _externalIdentifier;
+            set
+            {
+                _externalIdentifier = value;
+                _externalIdentifierSet = true;
+            }
+        }
+
+        private string? _externalIdentifier = null;
+
+        private bool _externalIdentifierSet = false;
+
+        public bool ShouldSerializeExternalIdentifier() => _externalIdentifierSet;
 
         /// <summary>
         /// Additional information about the transaction stored as key-value pairs. If provided, the whole value will be overridden.
         /// </summary>
-        [JsonProperty("metadata")]
-        public Dictionary<string, string>? Metadata { get; set; } = null;
+        [JsonProperty("metadata", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? Metadata
+        {
+            get => _metadata;
+            set
+            {
+                _metadata = value;
+                _metadataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _metadata = null;
+
+        private bool _metadataSet = false;
+
+        public bool ShouldSerializeMetadata() => _metadataSet;
 
         /// <summary>
         /// Allows for passing optional configuration per connection to take advantage of connection specific features. When provided, the data is only passed to the target connection type to prevent sharing configuration across connections. Please note that each of the keys this object are in kebab-case, for example `cybersource-anti-fraud` as they represent the ID of the connector. All the other keys will be snake case, for example `merchant_defined_data` or camel case to match an external API that the connector uses. If provided, the whole value will be overridden.
         /// </summary>
-        [JsonProperty("connection_options")]
-        public TransactionConnectionOptions? ConnectionOptions { get; set; } = null;
+        [JsonProperty("connection_options", NullValueHandling = NullValueHandling.Include)]
+        public TransactionConnectionOptions? ConnectionOptions
+        {
+            get => _connectionOptions;
+            set
+            {
+                _connectionOptions = value;
+                _connectionOptionsSet = true;
+            }
+        }
+
+        private TransactionConnectionOptions? _connectionOptions = null;
+
+        private bool _connectionOptionsSet = false;
+
+        public bool ShouldSerializeConnectionOptions() => _connectionOptionsSet;
     }
 }


### PR DESCRIPTION
## Summary

The single-PR home for the tri-state nullable fix on `*Update` request models. Designed so that when Speakeasy ships native tri-state on the C# generator, reverting this one PR removes the entire workaround.

Stacks on #197 (the revert of the original #193). Land #197 first, then this. After this lands, the history is two cleanly-revertable PRs: #197 takes main back to a clean baseline; this PR re-introduces the fix as one atomic unit.

## Why a re-do

The first attempt (#193) shipped the fix but wired the post-regen patch via `needs.generate.outputs.csharp_regenerated`. Speakeasy's reusable workflow declares those outputs at the job level only — not under `on.workflow_call.outputs` — so callers see them as empty strings, the condition `'' == 'true'` always evaluated false, and the patch job was silently skipped on every regen. The visible symptom was PR #195 (SDK 2.8.16): regenerated `*Update.cs` files reverted to plain auto-properties while the tri-state tests stayed in place, so CI failed.

## What's in this PR

| Path | Purpose |
|---|---|
| `src/Gr4vy/Models/Components/*Update.cs` (×10) | Tri-state rewrite: backing field + `ShouldSerialize{X}()` + `NullValueHandling.Include` on each nullable property. |
| `.speakeasy/scripts/patch_update_models.py` | Idempotent post-gen patch script. Bows out per-file when `ShouldSerialize` is already present, so it retires cleanly when Speakeasy ships native support. |
| `.github/workflows/patch_speakeasy_regen.yaml` | **New** trigger. Fires on `pull_request: opened/reopened/synchronize` filtered to `speakeasy-sdk-regen-*` branches, runs the patch script, pushes back with `DISPATCH_ACCESS_TOKEN` so CI re-runs on the patched commit. |
| `.github/workflows/sdk_generation.yaml` | Restores `always() &&` on the `notify` job so the Slack alert actually fires when `generate` fails. |
| `src/Gr4vy.Tests/UpdateModelSerializationTest.cs` | JSON-shape unit tests for unset / explicit-null / value across `string?`, `bool?`, `long?`, `List<string>?`, `Dictionary<string,string>?`, object. |
| `src/Gr4vy.Tests/BuyersUpdateIntegrationTest.cs` | E2E sandbox tests proving explicit null clears server-side, untouched fields are preserved, value assignments overwrite. |

## Behavior

| Caller action | Wire result |
|---|---|
| never assigns prop | omitted |
| assigns `null` | `"field": null` (new — was silently dropped) |
| assigns value | sent as value |

`ShouldSerialize{X}()` is honored by Newtonsoft.Json regardless of `NullValueHandling`, so unset properties stay omitted while explicitly-null properties are sent.

## Sequencing tradeoff with the trigger

`pull_request: opened` is event-driven rather than chained, so the timeline on each regen PR is:

1. Speakeasy creates the PR with the regenerated (un-patched) code.
2. CI runs once on that commit and **fails**.
3. This workflow patches and pushes back via PAT.
4. CI re-runs on the patched commit and passes.

The first red CI status is briefly visible on each regen PR. Acceptable for an automated PR flow, worth noting for reviewers.

## Test plan

- [x] #197 (revert) merges first.
- [x] This PR's `dotnet test` passes locally and in CI (matches behavior on the original #193 once that PR's tests merged).
- [x] After this PR lands, force a fresh `workflow_dispatch` on `sdk_generation.yaml` and verify the next `speakeasy-sdk-regen-*` PR shows: (a) the new `patch` workflow job runs, (b) it produces a follow-up commit, (c) CI re-runs and passes.
