### PR TITLE
fix: pin actions to approved SHAs in regen patcher workflow

### DIFF
--- a/.github/workflows/patch_speakeasy_regen.yaml
+++ b/.github/workflows/patch_speakeasy_regen.yaml
@@ -45,24 +45,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch (trusted source of patch script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: base
           persist-credentials: false
 
       - name: Checkout PR head (untrusted)
-        uses: actions/checkout@v4
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: head
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
+      # The patch script uses only Python stdlib (re, sys, pathlib, argparse),
+      # so we rely on the system python3 that ships with the ubuntu-latest
+      # runner rather than introducing a new pinned `actions/setup-python`
+      # SHA. This also keeps the dependency surface narrow.
       - name: Apply tri-state nullable patch using trusted script against PR head
         run: python3 base/.speakeasy/scripts/patch_update_models.py head
 


### PR DESCRIPTION
## Summary

Followup to #196. The new `patch_speakeasy_regen` workflow failed at the "Set up job" step on PR #198 (and would on every subsequent regen) with:

> The actions actions/checkout@v4 and actions/setup-python@v5 are not allowed in gr4vy/gr4vy-csharp because all actions must be pinned to a full-length commit SHA.

I'd shipped the workflow with `@v4` / `@v5` version tags but this repo enforces full-SHA pinning. Visible failure: https://github.com/gr4vy/gr4vy-csharp/actions/runs/26159589781/job/76947763937

## Fix

- Switch both `actions/checkout` calls to the v2 SHA that `ci.yaml` already trusts: `ee0669bd1cc54295c223e0bb666b733df41de1c5`. v2 supports every option this workflow uses (`ref`, `path`, `persist-credentials`).
- Drop the `actions/setup-python` step entirely. The patch script only uses Python stdlib (`re`, `sys`, `pathlib`, `argparse`), so the system `python3` on `ubuntu-latest` is enough. Avoids introducing a new pinned action just for one step.

## Test plan

- [ ] Land this PR.
- [ ] Reopen / re-trigger PR #198 (or wait for the next scheduled regen) and confirm the `patch` job now runs cleanly past "Set up job", applies the tri-state patch, and pushes a follow-up commit that turns CI green.
- [ ] If that succeeds, mergeable_state on regen PRs returns to "clean" without manual intervention.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cot4RdF4vuWbtFtX2sQnXr)_