### PR TITLE
fix: extend tri-state nullable patch to nested component types

### DIFF
--- a/.speakeasy/scripts/patch_update_models.py
+++ b/.speakeasy/scripts/patch_update_models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Post-generation patch for *Update.cs models.
+Post-generation patch for *Update.cs models and the component types they embed.
 
 Speakeasy emits update-request models with auto-properties like:
 
@@ -28,6 +28,16 @@ attribute to `NullValueHandling.Include` on each touched property.
 Properties whose generated default is a non-null literal (e.g. `= false`)
 are initialized with `_xSet = true` to preserve today's behavior of sending
 that default value on the wire.
+
+The patch covers two layers:
+
+1. The `*Update.cs` request models themselves.
+2. Every component type transitively reachable through the properties of
+   those update models (e.g. `BuyerUpdate.BillingDetails` is typed as the
+   shared `BillingDetails` class, which in turn embeds `Address`). Without
+   patching the nested types, callers can only clear top-level fields:
+   `BuyerUpdate.BillingDetails.Address.State = null` would be dropped by
+   the global `NullValueHandling.Ignore` setting before reaching the wire.
 
 The script is idempotent: re-running on already-patched code is a no-op
 (the auto-property regex no longer matches the rewritten form).
@@ -58,6 +68,29 @@ PROP_RE = re.compile(
 NULL_VALUE_HANDLING_RE = re.compile(
     r",?\s*NullValueHandling\s*=\s*NullValueHandling\.\w+"
 )
+
+# Matches any `[JsonProperty(...)]`-decorated property declaration, whether
+# it's still an auto-property or has already been rewritten to the
+# backing-field form. Used only to extract referenced type names for the
+# transitive walk — not for rewriting.
+TYPE_REF_RE = re.compile(
+    r"\[JsonProperty\([^\]]*\)\]\s*\n"
+    r"[ \t]*public\s+(?P<type_and_name>[^\n{=;]+)",
+    re.MULTILINE,
+)
+
+# C# / framework types that never resolve to a component file. Anything else
+# is checked against the components directory; if `{name}.cs` doesn't exist
+# the reference is silently dropped (covers nested generic args like enum
+# value types that happen to share a name).
+_PRIMITIVE_TYPES = frozenset({
+    "string", "int", "long", "short", "byte", "sbyte", "uint", "ulong",
+    "ushort", "bool", "double", "float", "decimal", "char", "object",
+    "DateTime", "DateTimeOffset", "TimeSpan", "Guid", "Uri", "Stream",
+    "List", "IList", "ICollection", "IEnumerable", "IReadOnlyList",
+    "IReadOnlyCollection", "Dictionary", "IDictionary",
+    "IReadOnlyDictionary", "Nullable", "Task", "HashSet", "ISet",
+})
 
 
 def force_null_value_handling_include(attr: str) -> str:
@@ -124,6 +157,56 @@ def patch_source(source: str) -> str | None:
     return "".join(out)
 
 
+def extract_referenced_type_names(source: str) -> set[str]:
+    """Return component type names referenced by `[JsonProperty]` properties.
+
+    Walks every property declaration regardless of whether the file has
+    already been patched. Generic wrappers are split apart so `List<Foo>`
+    yields `Foo`, `Dictionary<string, Bar>` yields `Bar`, etc.
+    """
+    refs: set[str] = set()
+    for m in TYPE_REF_RE.finditer(source):
+        type_and_name = m.group("type_and_name").strip()
+        space_idx = type_and_name.rfind(" ")
+        if space_idx < 0:
+            continue
+        type_str = type_and_name[:space_idx].strip()
+        for token in re.split(r"[<>,\s]+", type_str):
+            token = token.strip().rstrip("?")
+            if not token or token in _PRIMITIVE_TYPES:
+                continue
+            refs.add(token)
+    return refs
+
+
+def build_reachable_set(roots: list[Path], components: Path) -> set[Path]:
+    """BFS over property type references starting from each root file.
+
+    A type `Foo` is considered reachable iff `{components}/Foo.cs` exists.
+    Anonymous / union helper types (e.g. Speakeasy's `OneOf` files) that
+    don't have a matching component file are simply not visited.
+    """
+    visited: set[Path] = set()
+    queue: list[Path] = []
+    for root in roots:
+        if root not in visited:
+            visited.add(root)
+            queue.append(root)
+
+    while queue:
+        path = queue.pop()
+        try:
+            source = path.read_text()
+        except OSError:
+            continue
+        for type_name in extract_referenced_type_names(source):
+            candidate = components / f"{type_name}.cs"
+            if candidate.is_file() and candidate not in visited:
+                visited.add(candidate)
+                queue.append(candidate)
+    return visited
+
+
 def is_update_request_model(path: Path) -> bool:
     """Filter for files matching *Update.cs.
 
@@ -169,31 +252,37 @@ def main(argv: list[str]) -> int:
         print(f"error: components directory not found: {components}", file=sys.stderr)
         return 1
 
+    roots = [
+        p for p in sorted(components.glob("*Update.cs")) if is_update_request_model(p)
+    ]
+    reachable = build_reachable_set(roots, components)
+
     patched = 0
     skipped = 0
     native = 0
-    for path in sorted(components.glob("*Update.cs")):
-        if not is_update_request_model(path):
-            continue
+    for path in sorted(reachable):
+        rel = path.relative_to(repo_root)
         original = path.read_text()
         if "ShouldSerialize" in original:
             # The generator (or a previous run) has already emitted tri-state
             # for this model. Leave it alone so this patch retires cleanly
             # once Speakeasy ships native support.
-            print(f"native tri-state, leaving alone: {path.relative_to(repo_root)}")
+            print(f"native tri-state, leaving alone: {rel}")
             native += 1
             continue
         result = patch_source(original)
         if result is None or result == original:
-            print(f"skipped (no auto-property matches): {path.relative_to(repo_root)}")
+            print(f"skipped (no auto-property matches): {rel}")
             skipped += 1
             continue
         path.write_text(result)
-        print(f"patched: {path.relative_to(repo_root)}")
+        print(f"patched: {rel}")
         patched += 1
 
     print(
-        f"\n{patched} file(s) patched, {native} already tri-state, {skipped} skipped."
+        f"\n{patched} file(s) patched, {native} already tri-state, "
+        f"{skipped} skipped (across {len(reachable)} reachable file(s) "
+        f"from {len(roots)} *Update.cs root(s))."
     )
     return 0
 

--- a/src/Gr4vy.Tests/BuyersUpdateIntegrationTest.cs
+++ b/src/Gr4vy.Tests/BuyersUpdateIntegrationTest.cs
@@ -109,6 +109,68 @@ namespace Gr4vy.Tests
         }
 
         [Test]
+        public async Task NestedAddressField_ExplicitNull_ClearsOnServer()
+        {
+            // Mirrors the Wpay repro: clearing fields on a nested
+            // BillingDetails.Address must actually clear them server-side.
+            var created = await _client.Buyers.CreateAsync(
+                new BuyerCreate
+                {
+                    DisplayName = "Nested Clear",
+                    BillingDetails = new BillingDetails
+                    {
+                        FirstName = "Sean",
+                        LastName = "Lin",
+                        Address = new Address
+                        {
+                            City = "Auckland",
+                            Country = "NZ",
+                            PostalCode = "1010",
+                            State = "Auckland",
+                            HouseNumberOrName = "122A",
+                            Line1 = "122A Newton Road",
+                            Line2 = "Eden Terrace",
+                            Organization = "Acme",
+                        },
+                    },
+                }
+            );
+            Assert.That(created.Id, Is.Not.Null);
+
+            await _client.Buyers.UpdateAsync(
+                created.Id!,
+                new BuyerUpdate
+                {
+                    BillingDetails = new BillingDetails
+                    {
+                        Address = new Address
+                        {
+                            HouseNumberOrName = null,
+                            Line2 = null,
+                            State = null,
+                            Organization = null,
+                        },
+                    },
+                }
+            );
+
+            var fetched = await _client.Buyers.GetAsync(created.Id!);
+            Assert.That(fetched.BillingDetails, Is.Not.Null);
+            var addr = fetched.BillingDetails!.Address;
+            Assert.That(addr, Is.Not.Null);
+            Assert.That(addr!.HouseNumberOrName, Is.Null);
+            Assert.That(addr.Line2, Is.Null);
+            Assert.That(addr.State, Is.Null);
+            Assert.That(addr.Organization, Is.Null);
+            Assert.That(
+                addr.City,
+                Is.EqualTo("Auckland"),
+                "Untouched nested fields must not be cleared."
+            );
+            Assert.That(addr.Line1, Is.EqualTo("122A Newton Road"));
+        }
+
+        [Test]
         public async Task ExplicitValue_OverwritesField_OnServer()
         {
             var created = await _client.Buyers.CreateAsync(

--- a/src/Gr4vy.Tests/UpdateModelSerializationTest.cs
+++ b/src/Gr4vy.Tests/UpdateModelSerializationTest.cs
@@ -145,4 +145,47 @@ public class UpdateModelSerializationTests
         Assert.That(json["scheme_transaction_id"]!.Type, Is.EqualTo(JTokenType.Null));
         Assert.That(json.ContainsKey("scheme_transaction_id_scheme"), Is.False);
     }
+
+    [Test]
+    public void BuyerUpdate_NestedAddressField_ExplicitNullIsSentAsNull()
+    {
+        // Mirrors the Wpay repro: clearing a field on a nested object
+        // (BillingDetails.Address.HouseNumberOrName) must produce an
+        // explicit JSON null rather than omitting the key.
+        var update = new BuyerUpdate
+        {
+            BillingDetails = new BillingDetails
+            {
+                Address = new Address
+                {
+                    HouseNumberOrName = null,
+                    Line2 = null,
+                    State = null,
+                    Organization = null,
+                },
+            },
+        };
+        var json = SerializeToJObject(update);
+
+        var address = json["billing_details"]!["address"]!;
+        Assert.That(address["house_number_or_name"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(address["line2"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(address["state"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(address["organization"]!.Type, Is.EqualTo(JTokenType.Null));
+        Assert.That(address.ToObject<JObject>()!.ContainsKey("city"), Is.False,
+            "Unset nested fields must still be omitted.");
+    }
+
+    [Test]
+    public void BuyerUpdate_NestedAddressField_UnsetIsOmitted()
+    {
+        var update = new BuyerUpdate
+        {
+            BillingDetails = new BillingDetails { Address = new Address() },
+        };
+        var json = SerializeToJObject(update);
+        var address = json["billing_details"]!["address"]!.ToObject<JObject>()!;
+        Assert.That(address.Count, Is.EqualTo(0),
+            "An untouched nested Address must serialize as {}.");
+    }
 }

--- a/src/Gr4vy/Models/Components/AccountUpdaterOptions.cs
+++ b/src/Gr4vy/Models/Components/AccountUpdaterOptions.cs
@@ -23,25 +23,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// When the `response_code` is set to `updated`, the payment method's account number will be updated to this value.
         /// </summary>
-        [JsonProperty("account_number")]
-        public string? AccountNumber { get; set; } = null;
+        [JsonProperty("account_number", NullValueHandling = NullValueHandling.Include)]
+        public string? AccountNumber
+        {
+            get => _accountNumber;
+            set
+            {
+                _accountNumber = value;
+                _accountNumberSet = true;
+            }
+        }
+
+        private string? _accountNumber = null;
+
+        private bool _accountNumberSet = false;
+
+        public bool ShouldSerializeAccountNumber() => _accountNumberSet;
 
         /// <summary>
         /// When the `response_code` is set to `updated`, the payment method's expiration month will be updated to this value.
         /// </summary>
-        [JsonProperty("expiration_month")]
-        public string? ExpirationMonth { get; set; } = null;
+        [JsonProperty("expiration_month", NullValueHandling = NullValueHandling.Include)]
+        public string? ExpirationMonth
+        {
+            get => _expirationMonth;
+            set
+            {
+                _expirationMonth = value;
+                _expirationMonthSet = true;
+            }
+        }
+
+        private string? _expirationMonth = null;
+
+        private bool _expirationMonthSet = false;
+
+        public bool ShouldSerializeExpirationMonth() => _expirationMonthSet;
 
         /// <summary>
         /// When the `response_code` is set to `updated`, the payment method's expiration year will be updated to this value.
         /// </summary>
-        [JsonProperty("expiration_year")]
-        public string? ExpirationYear { get; set; } = null;
+        [JsonProperty("expiration_year", NullValueHandling = NullValueHandling.Include)]
+        public string? ExpirationYear
+        {
+            get => _expirationYear;
+            set
+            {
+                _expirationYear = value;
+                _expirationYearSet = true;
+            }
+        }
+
+        private string? _expirationYear = null;
+
+        private bool _expirationYearSet = false;
+
+        public bool ShouldSerializeExpirationYear() => _expirationYearSet;
 
         /// <summary>
         /// The type of error code to simulate.
         /// </summary>
-        [JsonProperty("error_code")]
-        public string? ErrorCode { get; set; } = null;
+        [JsonProperty("error_code", NullValueHandling = NullValueHandling.Include)]
+        public string? ErrorCode
+        {
+            get => _errorCode;
+            set
+            {
+                _errorCode = value;
+                _errorCodeSet = true;
+            }
+        }
+
+        private string? _errorCode = null;
+
+        private bool _errorCodeSet = false;
+
+        public bool ShouldSerializeErrorCode() => _errorCodeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/Address.cs
+++ b/src/Gr4vy/Models/Components/Address.cs
@@ -17,55 +17,181 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The city for the address.
         /// </summary>
-        [JsonProperty("city")]
-        public string? City { get; set; } = null;
+        [JsonProperty("city", NullValueHandling = NullValueHandling.Include)]
+        public string? City
+        {
+            get => _city;
+            set
+            {
+                _city = value;
+                _citySet = true;
+            }
+        }
+
+        private string? _city = null;
+
+        private bool _citySet = false;
+
+        public bool ShouldSerializeCity() => _citySet;
 
         /// <summary>
         /// The country for the address in ISO 3166 format.
         /// </summary>
-        [JsonProperty("country")]
-        public string? Country { get; set; } = null;
+        [JsonProperty("country", NullValueHandling = NullValueHandling.Include)]
+        public string? Country
+        {
+            get => _country;
+            set
+            {
+                _country = value;
+                _countrySet = true;
+            }
+        }
+
+        private string? _country = null;
+
+        private bool _countrySet = false;
+
+        public bool ShouldSerializeCountry() => _countrySet;
 
         /// <summary>
         /// The postal code or zip code for the address.
         /// </summary>
-        [JsonProperty("postal_code")]
-        public string? PostalCode { get; set; } = null;
+        [JsonProperty("postal_code", NullValueHandling = NullValueHandling.Include)]
+        public string? PostalCode
+        {
+            get => _postalCode;
+            set
+            {
+                _postalCode = value;
+                _postalCodeSet = true;
+            }
+        }
+
+        private string? _postalCode = null;
+
+        private bool _postalCodeSet = false;
+
+        public bool ShouldSerializePostalCode() => _postalCodeSet;
 
         /// <summary>
         /// The state, county, or province for the address.
         /// </summary>
-        [JsonProperty("state")]
-        public string? State { get; set; } = null;
+        [JsonProperty("state", NullValueHandling = NullValueHandling.Include)]
+        public string? State
+        {
+            get => _state;
+            set
+            {
+                _state = value;
+                _stateSet = true;
+            }
+        }
+
+        private string? _state = null;
+
+        private bool _stateSet = false;
+
+        public bool ShouldSerializeState() => _stateSet;
 
         /// <summary>
         /// The code of state, county, or province for the address in ISO 3166-2 format.
         /// </summary>
-        [JsonProperty("state_code")]
-        public string? StateCode { get; set; } = null;
+        [JsonProperty("state_code", NullValueHandling = NullValueHandling.Include)]
+        public string? StateCode
+        {
+            get => _stateCode;
+            set
+            {
+                _stateCode = value;
+                _stateCodeSet = true;
+            }
+        }
+
+        private string? _stateCode = null;
+
+        private bool _stateCodeSet = false;
+
+        public bool ShouldSerializeStateCode() => _stateCodeSet;
 
         /// <summary>
         /// The house number or name for the address. Not all payment services use this field but some do.
         /// </summary>
-        [JsonProperty("house_number_or_name")]
-        public string? HouseNumberOrName { get; set; } = null;
+        [JsonProperty("house_number_or_name", NullValueHandling = NullValueHandling.Include)]
+        public string? HouseNumberOrName
+        {
+            get => _houseNumberOrName;
+            set
+            {
+                _houseNumberOrName = value;
+                _houseNumberOrNameSet = true;
+            }
+        }
+
+        private string? _houseNumberOrName = null;
+
+        private bool _houseNumberOrNameSet = false;
+
+        public bool ShouldSerializeHouseNumberOrName() => _houseNumberOrNameSet;
 
         /// <summary>
         /// The first line of the address.
         /// </summary>
-        [JsonProperty("line1")]
-        public string? Line1 { get; set; } = null;
+        [JsonProperty("line1", NullValueHandling = NullValueHandling.Include)]
+        public string? Line1
+        {
+            get => _line1;
+            set
+            {
+                _line1 = value;
+                _line1Set = true;
+            }
+        }
+
+        private string? _line1 = null;
+
+        private bool _line1Set = false;
+
+        public bool ShouldSerializeLine1() => _line1Set;
 
         /// <summary>
         /// The second line of the address.
         /// </summary>
-        [JsonProperty("line2")]
-        public string? Line2 { get; set; } = null;
+        [JsonProperty("line2", NullValueHandling = NullValueHandling.Include)]
+        public string? Line2
+        {
+            get => _line2;
+            set
+            {
+                _line2 = value;
+                _line2Set = true;
+            }
+        }
+
+        private string? _line2 = null;
+
+        private bool _line2Set = false;
+
+        public bool ShouldSerializeLine2() => _line2Set;
 
         /// <summary>
         /// The optional name of the company or organisation to add to the address.
         /// </summary>
-        [JsonProperty("organization")]
-        public string? Organization { get; set; } = null;
+        [JsonProperty("organization", NullValueHandling = NullValueHandling.Include)]
+        public string? Organization
+        {
+            get => _organization;
+            set
+            {
+                _organization = value;
+                _organizationSet = true;
+            }
+        }
+
+        private string? _organization = null;
+
+        private bool _organizationSet = false;
+
+        public bool ShouldSerializeOrganization() => _organizationSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenCardOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenCardOptions.cs
@@ -19,37 +19,121 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Set to `true` to enable Auto Rescue for a transaction. Use the `maxDaysToRescue` to specify a rescue window.
         /// </summary>
-        [JsonProperty("autoRescue")]
-        public bool? AutoRescue { get; set; } = null;
+        [JsonProperty("autoRescue", NullValueHandling = NullValueHandling.Include)]
+        public bool? AutoRescue
+        {
+            get => _autoRescue;
+            set
+            {
+                _autoRescue = value;
+                _autoRescueSet = true;
+            }
+        }
+
+        private bool? _autoRescue = null;
+
+        private bool _autoRescueSet = false;
+
+        public bool ShouldSerializeAutoRescue() => _autoRescueSet;
 
         /// <summary>
         /// The rescue window for a transaction, in days, when `autoRescue` is set to `true`. You can specify a value between 1 and 48. For cards, the default is one calendar month. For SEPA, the default is 42 days.
         /// </summary>
-        [JsonProperty("maxDaysToRescue")]
-        public long? MaxDaysToRescue { get; set; } = null;
+        [JsonProperty("maxDaysToRescue", NullValueHandling = NullValueHandling.Include)]
+        public long? MaxDaysToRescue
+        {
+            get => _maxDaysToRescue;
+            set
+            {
+                _maxDaysToRescue = value;
+                _maxDaysToRescueSet = true;
+            }
+        }
+
+        private long? _maxDaysToRescue = null;
+
+        private bool _maxDaysToRescueSet = false;
+
+        public bool ShouldSerializeMaxDaysToRescue() => _maxDaysToRescueSet;
 
         /// <summary>
         /// Passes additional data to the Adyen API when creating a transaction.
         /// </summary>
-        [JsonProperty("additionalData")]
-        public Dictionary<string, string>? AdditionalData { get; set; } = null;
+        [JsonProperty("additionalData", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? AdditionalData
+        {
+            get => _additionalData;
+            set
+            {
+                _additionalData = value;
+                _additionalDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _additionalData = null;
+
+        private bool _additionalDataSet = false;
+
+        public bool ShouldSerializeAdditionalData() => _additionalDataSet;
 
         /// <summary>
         /// The rescue scenario to simulate for a transaction, when `autoRescue` is set to `true`.
         /// </summary>
-        [JsonProperty("autoRescueScenario")]
-        public string? AutoRescueScenario { get; set; } = null;
+        [JsonProperty("autoRescueScenario", NullValueHandling = NullValueHandling.Include)]
+        public string? AutoRescueScenario
+        {
+            get => _autoRescueScenario;
+            set
+            {
+                _autoRescueScenario = value;
+                _autoRescueScenarioSet = true;
+            }
+        }
+
+        private string? _autoRescueScenario = null;
+
+        private bool _autoRescueScenarioSet = false;
+
+        public bool ShouldSerializeAutoRescueScenario() => _autoRescueScenarioSet;
 
         /// <summary>
         /// The origin of the window where the payment is initiated, used for 3D Secure authentication.
         /// </summary>
-        [JsonProperty("window_origin")]
-        public string? WindowOrigin { get; set; } = null;
+        [JsonProperty("window_origin", NullValueHandling = NullValueHandling.Include)]
+        public string? WindowOrigin
+        {
+            get => _windowOrigin;
+            set
+            {
+                _windowOrigin = value;
+                _windowOriginSet = true;
+            }
+        }
+
+        private string? _windowOrigin = null;
+
+        private bool _windowOriginSet = false;
+
+        public bool ShouldSerializeWindowOrigin() => _windowOriginSet;
 
         /// <summary>
         /// Passes information of splitting payment amounts to the Adyen API.
         /// </summary>
-        [JsonProperty("splits")]
-        public AdyenSplitsOptions? Splits { get; set; } = null;
+        [JsonProperty("splits", NullValueHandling = NullValueHandling.Include)]
+        public AdyenSplitsOptions? Splits
+        {
+            get => _splits;
+            set
+            {
+                _splits = value;
+                _splitsSet = true;
+            }
+        }
+
+        private AdyenSplitsOptions? _splits = null;
+
+        private bool _splitsSet = false;
+
+        public bool ShouldSerializeSplits() => _splitsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes additional data to the Adyen API when creating a transaction.
         /// </summary>
-        [JsonProperty("additionalData")]
-        public Dictionary<string, string>? AdditionalData { get; set; } = null;
+        [JsonProperty("additionalData", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? AdditionalData
+        {
+            get => _additionalData;
+            set
+            {
+                _additionalData = value;
+                _additionalDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _additionalData = null;
+
+        private bool _additionalDataSet = false;
+
+        public bool ShouldSerializeAdditionalData() => _additionalDataSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenPixOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenPixOptions.cs
@@ -19,13 +19,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes additional data to the Adyen API when creating a transaction.
         /// </summary>
-        [JsonProperty("additionalData")]
-        public Dictionary<string, string>? AdditionalData { get; set; } = null;
+        [JsonProperty("additionalData", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? AdditionalData
+        {
+            get => _additionalData;
+            set
+            {
+                _additionalData = value;
+                _additionalDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _additionalData = null;
+
+        private bool _additionalDataSet = false;
+
+        public bool ShouldSerializeAdditionalData() => _additionalDataSet;
 
         /// <summary>
         /// Passes `pixRecurring` data to Adyen.
         /// </summary>
-        [JsonProperty("pixRecurring")]
-        public AdyenPixRecurringOptions? PixRecurring { get; set; } = null;
+        [JsonProperty("pixRecurring", NullValueHandling = NullValueHandling.Include)]
+        public AdyenPixRecurringOptions? PixRecurring
+        {
+            get => _pixRecurring;
+            set
+            {
+                _pixRecurring = value;
+                _pixRecurringSet = true;
+            }
+        }
+
+        private AdyenPixRecurringOptions? _pixRecurring = null;
+
+        private bool _pixRecurringSet = false;
+
+        public bool ShouldSerializePixRecurring() => _pixRecurringSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenPixRecurringAmount.cs
+++ b/src/Gr4vy/Models/Components/AdyenPixRecurringAmount.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Amount in the smallest currency unit for the given currency.
         /// </summary>
-        [JsonProperty("value")]
-        public long? Value { get; set; } = null;
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public long? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
+
+        private long? _value = null;
+
+        private bool _valueSet = false;
+
+        public bool ShouldSerializeValue() => _valueSet;
 
         /// <summary>
         /// ISO 4217 currency code.
         /// </summary>
-        [JsonProperty("currency")]
-        public string? Currency { get; set; } = null;
+        [JsonProperty("currency", NullValueHandling = NullValueHandling.Include)]
+        public string? Currency
+        {
+            get => _currency;
+            set
+            {
+                _currency = value;
+                _currencySet = true;
+            }
+        }
+
+        private string? _currency = null;
+
+        private bool _currencySet = false;
+
+        public bool ShouldSerializeCurrency() => _currencySet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenPixRecurringOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenPixRecurringOptions.cs
@@ -18,8 +18,22 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The frequency at which the shopper will be charged. Possible values: weekly, monthly, quarterly, half-yearly, and yearly.
         /// </summary>
-        [JsonProperty("frequency")]
-        public string? Frequency { get; set; } = null;
+        [JsonProperty("frequency", NullValueHandling = NullValueHandling.Include)]
+        public string? Frequency
+        {
+            get => _frequency;
+            set
+            {
+                _frequency = value;
+                _frequencySet = true;
+            }
+        }
+
+        private string? _frequency = null;
+
+        private bool _frequencySet = false;
+
+        public bool ShouldSerializeFrequency() => _frequencySet;
 
         /// <summary>
         /// For a billing plan where the payment amount is fixed, the currency and value for each recurring payment.
@@ -30,19 +44,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Start date of the billing plan, in YYYY-MM-DD format.
         /// </summary>
-        [JsonProperty("startsAt")]
-        public string? StartsAt { get; set; } = null;
+        [JsonProperty("startsAt", NullValueHandling = NullValueHandling.Include)]
+        public string? StartsAt
+        {
+            get => _startsAt;
+            set
+            {
+                _startsAt = value;
+                _startsAtSet = true;
+            }
+        }
+
+        private string? _startsAt = null;
+
+        private bool _startsAtSet = false;
+
+        public bool ShouldSerializeStartsAt() => _startsAtSet;
 
         /// <summary>
         /// End date of the billing plan, in YYYY-MM-DD format. The end date must align with the frequency and the start date of the billing plan. If left blank, the subscription will continue indefinitely unless it is cancelled by the shopper.
         /// </summary>
-        [JsonProperty("endsAt")]
-        public string? EndsAt { get; set; } = null;
+        [JsonProperty("endsAt", NullValueHandling = NullValueHandling.Include)]
+        public string? EndsAt
+        {
+            get => _endsAt;
+            set
+            {
+                _endsAt = value;
+                _endsAtSet = true;
+            }
+        }
+
+        private string? _endsAt = null;
+
+        private bool _endsAtSet = false;
+
+        public bool ShouldSerializeEndsAt() => _endsAtSet;
 
         /// <summary>
         /// The text that that will be shown on the shopper's bank statement for the recurring payments. We recommend to add a descriptive text about the subscription to let your shoppers recognize your recurring payments.
         /// </summary>
-        [JsonProperty("recurringStatement")]
-        public string? RecurringStatement { get; set; } = null;
+        [JsonProperty("recurringStatement", NullValueHandling = NullValueHandling.Include)]
+        public string? RecurringStatement
+        {
+            get => _recurringStatement;
+            set
+            {
+                _recurringStatement = value;
+                _recurringStatementSet = true;
+            }
+        }
+
+        private string? _recurringStatement = null;
+
+        private bool _recurringStatementSet = false;
+
+        public bool ShouldSerializeRecurringStatement() => _recurringStatementSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenSepaOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenSepaOptions.cs
@@ -18,31 +18,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Set to `true` to enable Auto Rescue for a transaction. Use the `maxDaysToRescue` to specify a rescue window.
         /// </summary>
-        [JsonProperty("autoRescue")]
-        public bool? AutoRescue { get; set; } = null;
+        [JsonProperty("autoRescue", NullValueHandling = NullValueHandling.Include)]
+        public bool? AutoRescue
+        {
+            get => _autoRescue;
+            set
+            {
+                _autoRescue = value;
+                _autoRescueSet = true;
+            }
+        }
+
+        private bool? _autoRescue = null;
+
+        private bool _autoRescueSet = false;
+
+        public bool ShouldSerializeAutoRescue() => _autoRescueSet;
 
         /// <summary>
         /// The rescue window for a transaction, in days, when `autoRescue` is set to `true`. You can specify a value between 1 and 48. For cards, the default is one calendar month. For SEPA, the default is 42 days.
         /// </summary>
-        [JsonProperty("maxDaysToRescue")]
-        public long? MaxDaysToRescue { get; set; } = null;
+        [JsonProperty("maxDaysToRescue", NullValueHandling = NullValueHandling.Include)]
+        public long? MaxDaysToRescue
+        {
+            get => _maxDaysToRescue;
+            set
+            {
+                _maxDaysToRescue = value;
+                _maxDaysToRescueSet = true;
+            }
+        }
+
+        private long? _maxDaysToRescue = null;
+
+        private bool _maxDaysToRescueSet = false;
+
+        public bool ShouldSerializeMaxDaysToRescue() => _maxDaysToRescueSet;
 
         /// <summary>
         /// Passes additional data to the Adyen API when creating a transaction.
         /// </summary>
-        [JsonProperty("additionalData")]
-        public Dictionary<string, string>? AdditionalData { get; set; } = null;
+        [JsonProperty("additionalData", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? AdditionalData
+        {
+            get => _additionalData;
+            set
+            {
+                _additionalData = value;
+                _additionalDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _additionalData = null;
+
+        private bool _additionalDataSet = false;
+
+        public bool ShouldSerializeAdditionalData() => _additionalDataSet;
 
         /// <summary>
         /// The rescue scenario to simulate for a transaction, when `autoRescue` is set to `true`.
         /// </summary>
-        [JsonProperty("autoRescueSepaScenario")]
-        public string? AutoRescueSepaScenario { get; set; } = null;
+        [JsonProperty("autoRescueSepaScenario", NullValueHandling = NullValueHandling.Include)]
+        public string? AutoRescueSepaScenario
+        {
+            get => _autoRescueSepaScenario;
+            set
+            {
+                _autoRescueSepaScenario = value;
+                _autoRescueSepaScenarioSet = true;
+            }
+        }
+
+        private string? _autoRescueSepaScenario = null;
+
+        private bool _autoRescueSepaScenarioSet = false;
+
+        public bool ShouldSerializeAutoRescueSepaScenario() => _autoRescueSepaScenarioSet;
 
         /// <summary>
         /// The name on the SEPA bank account.
         /// </summary>
-        [JsonProperty("ownerName")]
-        public string? OwnerName { get; set; } = null;
+        [JsonProperty("ownerName", NullValueHandling = NullValueHandling.Include)]
+        public string? OwnerName
+        {
+            get => _ownerName;
+            set
+            {
+                _ownerName = value;
+                _ownerNameSet = true;
+            }
+        }
+
+        private string? _ownerName = null;
+
+        private bool _ownerNameSet = false;
+
+        public bool ShouldSerializeOwnerName() => _ownerNameSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AdyenSplitsOptions.cs
+++ b/src/Gr4vy/Models/Components/AdyenSplitsOptions.cs
@@ -18,19 +18,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Split payment values to pass to the Adyen API on payment authorization. See <a href="https://docs.adyen.com/platforms/online-payments/split-transactions/split-payments-at-authorization/">the Adyen docs</a> for details on the format and contents of the list.
         /// </summary>
-        [JsonProperty("authorization")]
-        public List<Dictionary<string, object>>? Authorization { get; set; } = null;
+        [JsonProperty("authorization", NullValueHandling = NullValueHandling.Include)]
+        public List<Dictionary<string, object>>? Authorization
+        {
+            get => _authorization;
+            set
+            {
+                _authorization = value;
+                _authorizationSet = true;
+            }
+        }
+
+        private List<Dictionary<string, object>>? _authorization = null;
+
+        private bool _authorizationSet = false;
+
+        public bool ShouldSerializeAuthorization() => _authorizationSet;
 
         /// <summary>
         /// Split payment values to pass to the Adyen API on payment capture. See <a href="https://docs.adyen.com/platforms/online-payments/split-transactions/split-payments-at-capture/">the Adyen docs</a> for details on the format and contents of the list.
         /// </summary>
-        [JsonProperty("capture")]
-        public List<Dictionary<string, object>>? Capture { get; set; } = null;
+        [JsonProperty("capture", NullValueHandling = NullValueHandling.Include)]
+        public List<Dictionary<string, object>>? Capture
+        {
+            get => _capture;
+            set
+            {
+                _capture = value;
+                _captureSet = true;
+            }
+        }
+
+        private List<Dictionary<string, object>>? _capture = null;
+
+        private bool _captureSet = false;
+
+        public bool ShouldSerializeCapture() => _captureSet;
 
         /// <summary>
         /// Split payment values to pass to the Adyen API on payment refund. See <a href="https://docs.adyen.com/platforms/online-payments/split-transactions/split-refunds/">the Adyen docs</a> for details on the format and contents of the list.
         /// </summary>
-        [JsonProperty("refund")]
-        public List<Dictionary<string, object>>? Refund { get; set; } = null;
+        [JsonProperty("refund", NullValueHandling = NullValueHandling.Include)]
+        public List<Dictionary<string, object>>? Refund
+        {
+            get => _refund;
+            set
+            {
+                _refund = value;
+                _refundSet = true;
+            }
+        }
+
+        private List<Dictionary<string, object>>? _refund = null;
+
+        private bool _refundSet = false;
+
+        public bool ShouldSerializeRefund() => _refundSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AffirmItineraryOptions.cs
+++ b/src/Gr4vy/Models/Components/AffirmItineraryOptions.cs
@@ -17,43 +17,141 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The type of itinerary object.
         /// </summary>
-        [JsonProperty("type")]
-        public string? Type { get; set; } = null;
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Include)]
+        public string? Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _typeSet = true;
+            }
+        }
+
+        private string? _type = null;
+
+        private bool _typeSet = false;
+
+        public bool ShouldSerializeType() => _typeSet;
 
         /// <summary>
         /// The booking/itinerary number (if applicable).
         /// </summary>
-        [JsonProperty("sku")]
-        public string? Sku { get; set; } = null;
+        [JsonProperty("sku", NullValueHandling = NullValueHandling.Include)]
+        public string? Sku
+        {
+            get => _sku;
+            set
+            {
+                _sku = value;
+                _skuSet = true;
+            }
+        }
+
+        private string? _sku = null;
+
+        private bool _skuSet = false;
+
+        public bool ShouldSerializeSku() => _skuSet;
 
         /// <summary>
         /// Readable description of the itinerary item.
         /// </summary>
-        [JsonProperty("display_name")]
-        public string? DisplayName { get; set; } = null;
+        [JsonProperty("display_name", NullValueHandling = NullValueHandling.Include)]
+        public string? DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                _displayName = value;
+                _displayNameSet = true;
+            }
+        }
+
+        private string? _displayName = null;
+
+        private bool _displayNameSet = false;
+
+        public bool ShouldSerializeDisplayName() => _displayNameSet;
 
         /// <summary>
         /// The name of the venue where the event is hosted.
         /// </summary>
-        [JsonProperty("venue")]
-        public string? Venue { get; set; } = null;
+        [JsonProperty("venue", NullValueHandling = NullValueHandling.Include)]
+        public string? Venue
+        {
+            get => _venue;
+            set
+            {
+                _venue = value;
+                _venueSet = true;
+            }
+        }
+
+        private string? _venue = null;
+
+        private bool _venueSet = false;
+
+        public bool ShouldSerializeVenue() => _venueSet;
 
         /// <summary>
         /// The address object that can be parsed.
         /// </summary>
-        [JsonProperty("location")]
-        public string? Location { get; set; } = null;
+        [JsonProperty("location", NullValueHandling = NullValueHandling.Include)]
+        public string? Location
+        {
+            get => _location;
+            set
+            {
+                _location = value;
+                _locationSet = true;
+            }
+        }
+
+        private string? _location = null;
+
+        private bool _locationSet = false;
+
+        public bool ShouldSerializeLocation() => _locationSet;
 
         /// <summary>
         /// The start date of this itinerary item.
         /// </summary>
-        [JsonProperty("date_start")]
-        public string? DateStart { get; set; } = null;
+        [JsonProperty("date_start", NullValueHandling = NullValueHandling.Include)]
+        public string? DateStart
+        {
+            get => _dateStart;
+            set
+            {
+                _dateStart = value;
+                _dateStartSet = true;
+            }
+        }
+
+        private string? _dateStart = null;
+
+        private bool _dateStartSet = false;
+
+        public bool ShouldSerializeDateStart() => _dateStartSet;
 
         /// <summary>
         /// The corporation.
         /// </summary>
-        [JsonProperty("management")]
-        public string? Management { get; set; } = null;
+        [JsonProperty("management", NullValueHandling = NullValueHandling.Include)]
+        public string? Management
+        {
+            get => _management;
+            set
+            {
+                _management = value;
+                _managementSet = true;
+            }
+        }
+
+        private string? _management = null;
+
+        private bool _managementSet = false;
+
+        public bool ShouldSerializeManagement() => _managementSet;
     }
 }

--- a/src/Gr4vy/Models/Components/AffirmOptions.cs
+++ b/src/Gr4vy/Models/Components/AffirmOptions.cs
@@ -19,13 +19,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes additional discounts to the Affirm widget.
         /// </summary>
-        [JsonProperty("discounts")]
-        public Dictionary<string, Dictionary<string, object>>? Discounts { get; set; } = null;
+        [JsonProperty("discounts", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, Dictionary<string, object>>? Discounts
+        {
+            get => _discounts;
+            set
+            {
+                _discounts = value;
+                _discountsSet = true;
+            }
+        }
+
+        private Dictionary<string, Dictionary<string, object>>? _discounts = null;
+
+        private bool _discountsSet = false;
+
+        public bool ShouldSerializeDiscounts() => _discountsSet;
 
         /// <summary>
         /// Passes itinerary data to the Affirm API.
         /// </summary>
-        [JsonProperty("itinerary")]
-        public AffirmItineraryOptions? Itinerary { get; set; } = null;
+        [JsonProperty("itinerary", NullValueHandling = NullValueHandling.Include)]
+        public AffirmItineraryOptions? Itinerary
+        {
+            get => _itinerary;
+            set
+            {
+                _itinerary = value;
+                _itinerarySet = true;
+            }
+        }
+
+        private AffirmItineraryOptions? _itinerary = null;
+
+        private bool _itinerarySet = false;
+
+        public bool ShouldSerializeItinerary() => _itinerarySet;
     }
 }

--- a/src/Gr4vy/Models/Components/BillingDetails.cs
+++ b/src/Gr4vy/Models/Components/BillingDetails.cs
@@ -18,37 +18,121 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The first name(s) or given name for the buyer.
         /// </summary>
-        [JsonProperty("first_name")]
-        public string? FirstName { get; set; } = null;
+        [JsonProperty("first_name", NullValueHandling = NullValueHandling.Include)]
+        public string? FirstName
+        {
+            get => _firstName;
+            set
+            {
+                _firstName = value;
+                _firstNameSet = true;
+            }
+        }
+
+        private string? _firstName = null;
+
+        private bool _firstNameSet = false;
+
+        public bool ShouldSerializeFirstName() => _firstNameSet;
 
         /// <summary>
         /// The last name, or family name, of the buyer.
         /// </summary>
-        [JsonProperty("last_name")]
-        public string? LastName { get; set; } = null;
+        [JsonProperty("last_name", NullValueHandling = NullValueHandling.Include)]
+        public string? LastName
+        {
+            get => _lastName;
+            set
+            {
+                _lastName = value;
+                _lastNameSet = true;
+            }
+        }
+
+        private string? _lastName = null;
+
+        private bool _lastNameSet = false;
+
+        public bool ShouldSerializeLastName() => _lastNameSet;
 
         /// <summary>
         /// The email address for the buyer.
         /// </summary>
-        [JsonProperty("email_address")]
-        public string? EmailAddress { get; set; } = null;
+        [JsonProperty("email_address", NullValueHandling = NullValueHandling.Include)]
+        public string? EmailAddress
+        {
+            get => _emailAddress;
+            set
+            {
+                _emailAddress = value;
+                _emailAddressSet = true;
+            }
+        }
+
+        private string? _emailAddress = null;
+
+        private bool _emailAddressSet = false;
+
+        public bool ShouldSerializeEmailAddress() => _emailAddressSet;
 
         /// <summary>
         /// The phone number for the buyer which should be formatted according to the E164 number standard.
         /// </summary>
-        [JsonProperty("phone_number")]
-        public string? PhoneNumber { get; set; } = null;
+        [JsonProperty("phone_number", NullValueHandling = NullValueHandling.Include)]
+        public string? PhoneNumber
+        {
+            get => _phoneNumber;
+            set
+            {
+                _phoneNumber = value;
+                _phoneNumberSet = true;
+            }
+        }
+
+        private string? _phoneNumber = null;
+
+        private bool _phoneNumberSet = false;
+
+        public bool ShouldSerializePhoneNumber() => _phoneNumberSet;
 
         /// <summary>
         /// The billing address for the buyer.
         /// </summary>
-        [JsonProperty("address")]
-        public Address? Address { get; set; } = null;
+        [JsonProperty("address", NullValueHandling = NullValueHandling.Include)]
+        public Address? Address
+        {
+            get => _address;
+            set
+            {
+                _address = value;
+                _addressSet = true;
+            }
+        }
+
+        private Address? _address = null;
+
+        private bool _addressSet = false;
+
+        public bool ShouldSerializeAddress() => _addressSet;
 
         /// <summary>
         /// The tax ID information associated with the billing details.
         /// </summary>
-        [JsonProperty("tax_id")]
-        public TaxId? TaxId { get; set; } = null;
+        [JsonProperty("tax_id", NullValueHandling = NullValueHandling.Include)]
+        public TaxId? TaxId
+        {
+            get => _taxId;
+            set
+            {
+                _taxId = value;
+                _taxIdSet = true;
+            }
+        }
+
+        private TaxId? _taxId = null;
+
+        private bool _taxIdSet = false;
+
+        public bool ShouldSerializeTaxId() => _taxIdSet;
     }
 }

--- a/src/Gr4vy/Models/Components/BraintreeDynamicDataFieldsOptions.cs
+++ b/src/Gr4vy/Models/Components/BraintreeDynamicDataFieldsOptions.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes the 3DS status to the Braintree API using `customFields` with the key set to the value of `three_ds_auth_status`
         /// </summary>
-        [JsonProperty("three_ds_auth_status")]
-        public string? ThreeDsAuthStatus { get; set; } = null;
+        [JsonProperty("three_ds_auth_status", NullValueHandling = NullValueHandling.Include)]
+        public string? ThreeDsAuthStatus
+        {
+            get => _threeDsAuthStatus;
+            set
+            {
+                _threeDsAuthStatus = value;
+                _threeDsAuthStatusSet = true;
+            }
+        }
+
+        private string? _threeDsAuthStatus = null;
+
+        private bool _threeDsAuthStatusSet = false;
+
+        public bool ShouldSerializeThreeDsAuthStatus() => _threeDsAuthStatusSet;
 
         /// <summary>
         /// Passes the `transaction.purchaseOrderNumber` field when creating a new transaction.
         /// </summary>
-        [JsonProperty("purchase_order_number")]
-        public string? PurchaseOrderNumber { get; set; } = null;
+        [JsonProperty("purchase_order_number", NullValueHandling = NullValueHandling.Include)]
+        public string? PurchaseOrderNumber
+        {
+            get => _purchaseOrderNumber;
+            set
+            {
+                _purchaseOrderNumber = value;
+                _purchaseOrderNumberSet = true;
+            }
+        }
+
+        private string? _purchaseOrderNumber = null;
+
+        private bool _purchaseOrderNumberSet = false;
+
+        public bool ShouldSerializePurchaseOrderNumber() => _purchaseOrderNumberSet;
 
         /// <summary>
         /// Passes the `vaultPaymentMethodCriteria` field when creating a new transaction.
         /// </summary>
-        [JsonProperty("vault_payment_method_criteria")]
-        public string? VaultPaymentMethodCriteria { get; set; } = null;
+        [JsonProperty("vault_payment_method_criteria", NullValueHandling = NullValueHandling.Include)]
+        public string? VaultPaymentMethodCriteria
+        {
+            get => _vaultPaymentMethodCriteria;
+            set
+            {
+                _vaultPaymentMethodCriteria = value;
+                _vaultPaymentMethodCriteriaSet = true;
+            }
+        }
+
+        private string? _vaultPaymentMethodCriteria = null;
+
+        private bool _vaultPaymentMethodCriteriaSet = false;
+
+        public bool ShouldSerializeVaultPaymentMethodCriteria() => _vaultPaymentMethodCriteriaSet;
     }
 }

--- a/src/Gr4vy/Models/Components/BraintreeOptions.cs
+++ b/src/Gr4vy/Models/Components/BraintreeOptions.cs
@@ -19,19 +19,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes a discount amount to be applied to the transaction when using Braintree.
         /// </summary>
-        [JsonProperty("discount_amount")]
-        public long? DiscountAmount { get; set; } = null;
+        [JsonProperty("discount_amount", NullValueHandling = NullValueHandling.Include)]
+        public long? DiscountAmount
+        {
+            get => _discountAmount;
+            set
+            {
+                _discountAmount = value;
+                _discountAmountSet = true;
+            }
+        }
+
+        private long? _discountAmount = null;
+
+        private bool _discountAmountSet = false;
+
+        public bool ShouldSerializeDiscountAmount() => _discountAmountSet;
 
         /// <summary>
         /// Passes `customFields` to the Braintree API when creating a new payment. Custom fields allow you to customize your checkout experience by collecting specific information about your customers and their purchases.
         /// </summary>
-        [JsonProperty("custom_fields")]
-        public Dictionary<string, string>? CustomFields { get; set; } = null;
+        [JsonProperty("custom_fields", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? CustomFields
+        {
+            get => _customFields;
+            set
+            {
+                _customFields = value;
+                _customFieldsSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _customFields = null;
+
+        private bool _customFieldsSet = false;
+
+        public bool ShouldSerializeCustomFields() => _customFieldsSet;
 
         /// <summary>
         /// Additional dynamic fields to pass to the Braintree API.
         /// </summary>
-        [JsonProperty("dynamic_data_fields")]
-        public BraintreeDynamicDataFieldsOptions? DynamicDataFields { get; set; } = null;
+        [JsonProperty("dynamic_data_fields", NullValueHandling = NullValueHandling.Include)]
+        public BraintreeDynamicDataFieldsOptions? DynamicDataFields
+        {
+            get => _dynamicDataFields;
+            set
+            {
+                _dynamicDataFields = value;
+                _dynamicDataFieldsSet = true;
+            }
+        }
+
+        private BraintreeDynamicDataFieldsOptions? _dynamicDataFields = null;
+
+        private bool _dynamicDataFieldsSet = false;
+
+        public bool ShouldSerializeDynamicDataFields() => _dynamicDataFieldsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ChaseOptions.cs
+++ b/src/Gr4vy/Models/Components/ChaseOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Custom order comment.
         /// </summary>
-        [JsonProperty("comments")]
-        public string? Comments { get; set; } = null;
+        [JsonProperty("comments", NullValueHandling = NullValueHandling.Include)]
+        public string? Comments
+        {
+            get => _comments;
+            set
+            {
+                _comments = value;
+                _commentsSet = true;
+            }
+        }
+
+        private string? _comments = null;
+
+        private bool _commentsSet = false;
+
+        public bool ShouldSerializeComments() => _commentsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/CybersourceAntiFraudOptions.cs
+++ b/src/Gr4vy/Models/Components/CybersourceAntiFraudOptions.cs
@@ -18,19 +18,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// A list of merchant defined data to be passed to the Cybersource Decision Manager API. Each key needs to be a numeric string.
         /// </summary>
-        [JsonProperty("merchant_defined_data")]
-        public Dictionary<string, string>? MerchantDefinedData { get; set; } = null;
+        [JsonProperty("merchant_defined_data", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? MerchantDefinedData
+        {
+            get => _merchantDefinedData;
+            set
+            {
+                _merchantDefinedData = value;
+                _merchantDefinedDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _merchantDefinedData = null;
+
+        private bool _merchantDefinedDataSet = false;
+
+        public bool ShouldSerializeMerchantDefinedData() => _merchantDefinedDataSet;
 
         /// <summary>
         /// The merchant ID to use for this transaction. This requires a meta key to be set up for use with Cybersource Decision Manager, and this overrides the connector configuration.
         /// </summary>
-        [JsonProperty("meta_key_merchant_id")]
-        public string? MetaKeyMerchantId { get; set; } = null;
+        [JsonProperty("meta_key_merchant_id", NullValueHandling = NullValueHandling.Include)]
+        public string? MetaKeyMerchantId
+        {
+            get => _metaKeyMerchantId;
+            set
+            {
+                _metaKeyMerchantId = value;
+                _metaKeyMerchantIdSet = true;
+            }
+        }
+
+        private string? _metaKeyMerchantId = null;
+
+        private bool _metaKeyMerchantIdSet = false;
+
+        public bool ShouldSerializeMetaKeyMerchantId() => _metaKeyMerchantIdSet;
 
         /// <summary>
         /// The shipping method for this transaction.
         /// </summary>
-        [JsonProperty("shipping_method")]
-        public string? ShippingMethod { get; set; } = null;
+        [JsonProperty("shipping_method", NullValueHandling = NullValueHandling.Include)]
+        public string? ShippingMethod
+        {
+            get => _shippingMethod;
+            set
+            {
+                _shippingMethod = value;
+                _shippingMethodSet = true;
+            }
+        }
+
+        private string? _shippingMethod = null;
+
+        private bool _shippingMethodSet = false;
+
+        public bool ShouldSerializeShippingMethod() => _shippingMethodSet;
     }
 }

--- a/src/Gr4vy/Models/Components/CybersourceOptions.cs
+++ b/src/Gr4vy/Models/Components/CybersourceOptions.cs
@@ -18,25 +18,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The merchant ID to use for this transaction. This requires a meta key to be set up for use with Cybersource, and this overrides the connector configuration.
         /// </summary>
-        [JsonProperty("meta_key_merchant_id")]
-        public string? MetaKeyMerchantId { get; set; } = null;
+        [JsonProperty("meta_key_merchant_id", NullValueHandling = NullValueHandling.Include)]
+        public string? MetaKeyMerchantId
+        {
+            get => _metaKeyMerchantId;
+            set
+            {
+                _metaKeyMerchantId = value;
+                _metaKeyMerchantIdSet = true;
+            }
+        }
+
+        private string? _metaKeyMerchantId = null;
+
+        private bool _metaKeyMerchantIdSet = false;
+
+        public bool ShouldSerializeMetaKeyMerchantId() => _metaKeyMerchantIdSet;
 
         /// <summary>
         /// A list of merchant defined data to be passed to the Cybersource. Each key needs to be a numeric string.
         /// </summary>
-        [JsonProperty("merchant_defined_information")]
-        public Dictionary<string, string>? MerchantDefinedInformation { get; set; } = null;
+        [JsonProperty("merchant_defined_information", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? MerchantDefinedInformation
+        {
+            get => _merchantDefinedInformation;
+            set
+            {
+                _merchantDefinedInformation = value;
+                _merchantDefinedInformationSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _merchantDefinedInformation = null;
+
+        private bool _merchantDefinedInformationSet = false;
+
+        public bool ShouldSerializeMerchantDefinedInformation() => _merchantDefinedInformationSet;
 
         /// <summary>
         /// The shipping method for this transaction.
         /// </summary>
-        [JsonProperty("ship_to_method")]
-        public string? ShipToMethod { get; set; } = null;
+        [JsonProperty("ship_to_method", NullValueHandling = NullValueHandling.Include)]
+        public string? ShipToMethod
+        {
+            get => _shipToMethod;
+            set
+            {
+                _shipToMethod = value;
+                _shipToMethodSet = true;
+            }
+        }
+
+        private string? _shipToMethod = null;
+
+        private bool _shipToMethodSet = false;
+
+        public bool ShouldSerializeShipToMethod() => _shipToMethodSet;
 
         /// <summary>
         /// Brief description of the order or any comment you wish to add to the order.
         /// </summary>
-        [JsonProperty("comments")]
-        public string? Comments { get; set; } = null;
+        [JsonProperty("comments", NullValueHandling = NullValueHandling.Include)]
+        public string? Comments
+        {
+            get => _comments;
+            set
+            {
+                _comments = value;
+                _commentsSet = true;
+            }
+        }
+
+        private string? _comments = null;
+
+        private bool _commentsSet = false;
+
+        public bool ShouldSerializeComments() => _commentsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DigitalWalletAddress.cs
+++ b/src/Gr4vy/Models/Components/DigitalWalletAddress.cs
@@ -17,31 +17,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The first line of the address.
         /// </summary>
-        [JsonProperty("line1")]
-        public string Line1 { get; set; } = default!;
+        [JsonProperty("line1", NullValueHandling = NullValueHandling.Include)]
+        public string Line1
+        {
+            get => _line1;
+            set
+            {
+                _line1 = value;
+                _line1Set = true;
+            }
+        }
+
+        private string _line1 = default!;
+
+        private bool _line1Set = true;
+
+        public bool ShouldSerializeLine1() => _line1Set;
 
         /// <summary>
         /// The second line of the address.
         /// </summary>
-        [JsonProperty("line2")]
-        public string? Line2 { get; set; } = null;
+        [JsonProperty("line2", NullValueHandling = NullValueHandling.Include)]
+        public string? Line2
+        {
+            get => _line2;
+            set
+            {
+                _line2 = value;
+                _line2Set = true;
+            }
+        }
+
+        private string? _line2 = null;
+
+        private bool _line2Set = false;
+
+        public bool ShouldSerializeLine2() => _line2Set;
 
         /// <summary>
         /// The city for the address.
         /// </summary>
-        [JsonProperty("city")]
-        public string City { get; set; } = default!;
+        [JsonProperty("city", NullValueHandling = NullValueHandling.Include)]
+        public string City
+        {
+            get => _city;
+            set
+            {
+                _city = value;
+                _citySet = true;
+            }
+        }
+
+        private string _city = default!;
+
+        private bool _citySet = true;
+
+        public bool ShouldSerializeCity() => _citySet;
 
         /// <summary>
         /// The code of state, county, or province for the address in ISO 3166-2 format.
         /// </summary>
-        [JsonProperty("state_code")]
-        public string StateCode { get; set; } = default!;
+        [JsonProperty("state_code", NullValueHandling = NullValueHandling.Include)]
+        public string StateCode
+        {
+            get => _stateCode;
+            set
+            {
+                _stateCode = value;
+                _stateCodeSet = true;
+            }
+        }
+
+        private string _stateCode = default!;
+
+        private bool _stateCodeSet = true;
+
+        public bool ShouldSerializeStateCode() => _stateCodeSet;
 
         /// <summary>
         /// The zip or postal code for the address.
         /// </summary>
-        [JsonProperty("postal_code")]
-        public string PostalCode { get; set; } = default!;
+        [JsonProperty("postal_code", NullValueHandling = NullValueHandling.Include)]
+        public string PostalCode
+        {
+            get => _postalCode;
+            set
+            {
+                _postalCode = value;
+                _postalCodeSet = true;
+            }
+        }
+
+        private string _postalCode = default!;
+
+        private bool _postalCodeSet = true;
+
+        public bool ShouldSerializePostalCode() => _postalCodeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `wallet` data to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("wallet")]
-        public DlocalWalletOptions? Wallet { get; set; } = null;
+        [JsonProperty("wallet", NullValueHandling = NullValueHandling.Include)]
+        public DlocalWalletOptions? Wallet
+        {
+            get => _wallet;
+            set
+            {
+                _wallet = value;
+                _walletSet = true;
+            }
+        }
+
+        private DlocalWalletOptions? _wallet = null;
+
+        private bool _walletSet = false;
+
+        public bool ShouldSerializeWallet() => _walletSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalPIXOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalPIXOptions.cs
@@ -18,13 +18,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `subscription` data to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("subscription")]
-        public DlocalPIXSubscriptionOptions? Subscription { get; set; } = null;
+        [JsonProperty("subscription", NullValueHandling = NullValueHandling.Include)]
+        public DlocalPIXSubscriptionOptions? Subscription
+        {
+            get => _subscription;
+            set
+            {
+                _subscription = value;
+                _subscriptionSet = true;
+            }
+        }
+
+        private DlocalPIXSubscriptionOptions? _subscription = null;
+
+        private bool _subscriptionSet = false;
+
+        public bool ShouldSerializeSubscription() => _subscriptionSet;
 
         /// <summary>
         /// Defines scheduled payment start date. Must be provided in ISO 8601 format `(YYYY-MM-DD`). If not specified, The default is 2 days in the future.
         /// </summary>
-        [JsonProperty("scheduled_date")]
-        public string? ScheduledDate { get; set; } = null;
+        [JsonProperty("scheduled_date", NullValueHandling = NullValueHandling.Include)]
+        public string? ScheduledDate
+        {
+            get => _scheduledDate;
+            set
+            {
+                _scheduledDate = value;
+                _scheduledDateSet = true;
+            }
+        }
+
+        private string? _scheduledDate = null;
+
+        private bool _scheduledDateSet = false;
+
+        public bool ShouldSerializeScheduledDate() => _scheduledDateSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalPIXSubscriptionAmountOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalPIXSubscriptionAmountOptions.cs
@@ -17,14 +17,42 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates the amount type unit for the subscription. Allowed values are: `FIXED`, `VARIABLE`.
         /// </summary>
-        [JsonProperty("type")]
-        public string Type { get; set; } = default!;
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Include)]
+        public string Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _typeSet = true;
+            }
+        }
+
+        private string _type = default!;
+
+        private bool _typeSet = true;
+
+        public bool ShouldSerializeType() => _typeSet;
 
         /// <summary>
         /// Fixed subscription amount in local currency. Required only for fixed amount subscriptions depending on the payment method.
         /// </summary>
-        [JsonProperty("value")]
-        public string? Value { get; set; } = null;
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public string? Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
+
+        private string? _value = null;
+
+        private bool _valueSet = false;
+
+        public bool ShouldSerializeValue() => _valueSet;
 
         /// <summary>
         /// Minimum payer enrollment limit, not minimum recurring charge amount.

--- a/src/Gr4vy/Models/Components/DlocalPIXSubscriptionOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalPIXSubscriptionOptions.cs
@@ -18,25 +18,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `subscription.amount` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("amount")]
-        public DlocalPIXSubscriptionAmountOptions? Amount { get; set; } = null;
+        [JsonProperty("amount", NullValueHandling = NullValueHandling.Include)]
+        public DlocalPIXSubscriptionAmountOptions? Amount
+        {
+            get => _amount;
+            set
+            {
+                _amount = value;
+                _amountSet = true;
+            }
+        }
+
+        private DlocalPIXSubscriptionAmountOptions? _amount = null;
+
+        private bool _amountSet = false;
+
+        public bool ShouldSerializeAmount() => _amountSet;
 
         /// <summary>
         /// Indicates the frequency unit for the subscription. Allowed values are: `WEEKLY`, `MONTHLY`, `QUARTERLY`, `SEMI_ANNUAL`, `ANNUAL`.
         /// </summary>
-        [JsonProperty("frequency")]
-        public string Frequency { get; set; } = default!;
+        [JsonProperty("frequency", NullValueHandling = NullValueHandling.Include)]
+        public string Frequency
+        {
+            get => _frequency;
+            set
+            {
+                _frequency = value;
+                _frequencySet = true;
+            }
+        }
+
+        private string _frequency = default!;
+
+        private bool _frequencySet = true;
+
+        public bool ShouldSerializeFrequency() => _frequencySet;
 
         /// <summary>
         /// Defines subscription start date. Must be provided in ISO 8601 format `(YYYY-MM-DD`). If not specified, The default is the current date.
         /// </summary>
-        [JsonProperty("start_date")]
-        public string? StartDate { get; set; } = null;
+        [JsonProperty("start_date", NullValueHandling = NullValueHandling.Include)]
+        public string? StartDate
+        {
+            get => _startDate;
+            set
+            {
+                _startDate = value;
+                _startDateSet = true;
+            }
+        }
+
+        private string? _startDate = null;
+
+        private bool _startDateSet = false;
+
+        public bool ShouldSerializeStartDate() => _startDateSet;
 
         /// <summary>
         /// Defines subscription expiration date. Must be provided in ISO 8601 format `(YYYY-MM-DD`). If not provided, the subscription will not expire.
         /// </summary>
-        [JsonProperty("end_date")]
-        public string? EndDate { get; set; } = null;
+        [JsonProperty("end_date", NullValueHandling = NullValueHandling.Include)]
+        public string? EndDate
+        {
+            get => _endDate;
+            set
+            {
+                _endDate = value;
+                _endDateSet = true;
+            }
+        }
+
+        private string? _endDate = null;
+
+        private bool _endDateSet = false;
+
+        public bool ShouldSerializeEndDate() => _endDateSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalUPIOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalUPIOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `wallet` data to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("wallet")]
-        public DlocalUPIWalletOptions? Wallet { get; set; } = null;
+        [JsonProperty("wallet", NullValueHandling = NullValueHandling.Include)]
+        public DlocalUPIWalletOptions? Wallet
+        {
+            get => _wallet;
+            set
+            {
+                _wallet = value;
+                _walletSet = true;
+            }
+        }
+
+        private DlocalUPIWalletOptions? _wallet = null;
+
+        private bool _walletSet = false;
+
+        public bool ShouldSerializeWallet() => _walletSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalUPIRecurringInfoOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalUPIRecurringInfoOptions.cs
@@ -17,25 +17,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates the frequency unit for the subscription. Allowed values are: `DAY`, `WEEK`, `MONTH`, `BI_MONTHLY`, `QUARTER`, `SEMI_ANNUALLY`, `YEAR`, `ONDEMAND`.
         /// </summary>
-        [JsonProperty("subscription_frequency_unit")]
-        public string SubscriptionFrequencyUnit { get; set; } = default!;
+        [JsonProperty("subscription_frequency_unit", NullValueHandling = NullValueHandling.Include)]
+        public string SubscriptionFrequencyUnit
+        {
+            get => _subscriptionFrequencyUnit;
+            set
+            {
+                _subscriptionFrequencyUnit = value;
+                _subscriptionFrequencyUnitSet = true;
+            }
+        }
+
+        private string _subscriptionFrequencyUnit = default!;
+
+        private bool _subscriptionFrequencyUnitSet = true;
+
+        public bool ShouldSerializeSubscriptionFrequencyUnit() => _subscriptionFrequencyUnitSet;
 
         /// <summary>
         /// Indicates the frequency for the subscription.
         /// </summary>
-        [JsonProperty("subscription_frequency")]
-        public long SubscriptionFrequency { get; set; } = default!;
+        [JsonProperty("subscription_frequency", NullValueHandling = NullValueHandling.Include)]
+        public long SubscriptionFrequency
+        {
+            get => _subscriptionFrequency;
+            set
+            {
+                _subscriptionFrequency = value;
+                _subscriptionFrequencySet = true;
+            }
+        }
+
+        private long _subscriptionFrequency = default!;
+
+        private bool _subscriptionFrequencySet = true;
+
+        public bool ShouldSerializeSubscriptionFrequency() => _subscriptionFrequencySet;
 
         /// <summary>
         /// Indicates the start date for the subscription in format `YYYYMMDD`.
         /// </summary>
-        [JsonProperty("subscription_start_at")]
-        public string SubscriptionStartAt { get; set; } = default!;
+        [JsonProperty("subscription_start_at", NullValueHandling = NullValueHandling.Include)]
+        public string SubscriptionStartAt
+        {
+            get => _subscriptionStartAt;
+            set
+            {
+                _subscriptionStartAt = value;
+                _subscriptionStartAtSet = true;
+            }
+        }
+
+        private string _subscriptionStartAt = default!;
+
+        private bool _subscriptionStartAtSet = true;
+
+        public bool ShouldSerializeSubscriptionStartAt() => _subscriptionStartAtSet;
 
         /// <summary>
         /// Indicates the end date for the subscription in format `YYYYMMDD`.
         /// </summary>
-        [JsonProperty("subscription_end_at")]
-        public string SubscriptionEndAt { get; set; } = default!;
+        [JsonProperty("subscription_end_at", NullValueHandling = NullValueHandling.Include)]
+        public string SubscriptionEndAt
+        {
+            get => _subscriptionEndAt;
+            set
+            {
+                _subscriptionEndAt = value;
+                _subscriptionEndAtSet = true;
+            }
+        }
+
+        private string _subscriptionEndAt = default!;
+
+        private bool _subscriptionEndAtSet = true;
+
+        public bool ShouldSerializeSubscriptionEndAt() => _subscriptionEndAtSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalUPIWalletOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalUPIWalletOptions.cs
@@ -18,37 +18,121 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `wallet.name` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("name")]
-        public string? Name { get; set; } = null;
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Include)]
+        public string? Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                _nameSet = true;
+            }
+        }
+
+        private string? _name = null;
+
+        private bool _nameSet = false;
+
+        public bool ShouldSerializeName() => _nameSet;
 
         /// <summary>
         /// Passes `wallet.email` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("email")]
-        public string? Email { get; set; } = null;
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Include)]
+        public string? Email
+        {
+            get => _email;
+            set
+            {
+                _email = value;
+                _emailSet = true;
+            }
+        }
+
+        private string? _email = null;
+
+        private bool _emailSet = false;
+
+        public bool ShouldSerializeEmail() => _emailSet;
 
         /// <summary>
         /// Passes `wallet.token` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("token")]
-        public string? Token { get; set; } = null;
+        [JsonProperty("token", NullValueHandling = NullValueHandling.Include)]
+        public string? Token
+        {
+            get => _token;
+            set
+            {
+                _token = value;
+                _tokenSet = true;
+            }
+        }
+
+        private string? _token = null;
+
+        private bool _tokenSet = false;
+
+        public bool ShouldSerializeToken() => _tokenSet;
 
         /// <summary>
         /// Passes `wallet.username` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("username")]
-        public string? Username { get; set; } = null;
+        [JsonProperty("username", NullValueHandling = NullValueHandling.Include)]
+        public string? Username
+        {
+            get => _username;
+            set
+            {
+                _username = value;
+                _usernameSet = true;
+            }
+        }
+
+        private string? _username = null;
+
+        private bool _usernameSet = false;
+
+        public bool ShouldSerializeUsername() => _usernameSet;
 
         /// <summary>
         /// Passes `wallet.verify` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("verify")]
-        public bool? Verify { get; set; } = null;
+        [JsonProperty("verify", NullValueHandling = NullValueHandling.Include)]
+        public bool? Verify
+        {
+            get => _verify;
+            set
+            {
+                _verify = value;
+                _verifySet = true;
+            }
+        }
+
+        private bool? _verify = null;
+
+        private bool _verifySet = false;
+
+        public bool ShouldSerializeVerify() => _verifySet;
 
         /// <summary>
         /// Passes `wallet.recurring_info` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("recurring_info")]
-        public DlocalUPIRecurringInfoOptions? RecurringInfo { get; set; } = null;
+        [JsonProperty("recurring_info", NullValueHandling = NullValueHandling.Include)]
+        public DlocalUPIRecurringInfoOptions? RecurringInfo
+        {
+            get => _recurringInfo;
+            set
+            {
+                _recurringInfo = value;
+                _recurringInfoSet = true;
+            }
+        }
+
+        private DlocalUPIRecurringInfoOptions? _recurringInfo = null;
+
+        private bool _recurringInfoSet = false;
+
+        public bool ShouldSerializeRecurringInfo() => _recurringInfoSet;
     }
 }

--- a/src/Gr4vy/Models/Components/DlocalWalletOptions.cs
+++ b/src/Gr4vy/Models/Components/DlocalWalletOptions.cs
@@ -17,31 +17,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes `wallet.name` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("name")]
-        public string? Name { get; set; } = null;
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Include)]
+        public string? Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                _nameSet = true;
+            }
+        }
+
+        private string? _name = null;
+
+        private bool _nameSet = false;
+
+        public bool ShouldSerializeName() => _nameSet;
 
         /// <summary>
         /// Passes `wallet.email` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("email")]
-        public string? Email { get; set; } = null;
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Include)]
+        public string? Email
+        {
+            get => _email;
+            set
+            {
+                _email = value;
+                _emailSet = true;
+            }
+        }
+
+        private string? _email = null;
+
+        private bool _emailSet = false;
+
+        public bool ShouldSerializeEmail() => _emailSet;
 
         /// <summary>
         /// Passes `wallet.token` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("token")]
-        public string? Token { get; set; } = null;
+        [JsonProperty("token", NullValueHandling = NullValueHandling.Include)]
+        public string? Token
+        {
+            get => _token;
+            set
+            {
+                _token = value;
+                _tokenSet = true;
+            }
+        }
+
+        private string? _token = null;
+
+        private bool _tokenSet = false;
+
+        public bool ShouldSerializeToken() => _tokenSet;
 
         /// <summary>
         /// Passes `wallet.username` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("username")]
-        public string? Username { get; set; } = null;
+        [JsonProperty("username", NullValueHandling = NullValueHandling.Include)]
+        public string? Username
+        {
+            get => _username;
+            set
+            {
+                _username = value;
+                _usernameSet = true;
+            }
+        }
+
+        private string? _username = null;
+
+        private bool _usernameSet = false;
+
+        public bool ShouldSerializeUsername() => _usernameSet;
 
         /// <summary>
         /// Passes `wallet.verify` to the dLocal API for those connectors that need it.
         /// </summary>
-        [JsonProperty("verify")]
-        public bool? Verify { get; set; } = null;
+        [JsonProperty("verify", NullValueHandling = NullValueHandling.Include)]
+        public bool? Verify
+        {
+            get => _verify;
+            set
+            {
+                _verify = value;
+                _verifySet = true;
+            }
+        }
+
+        private bool? _verify = null;
+
+        private bool _verifySet = false;
+
+        public bool ShouldSerializeVerify() => _verifySet;
     }
 }

--- a/src/Gr4vy/Models/Components/EcommpayOptions.cs
+++ b/src/Gr4vy/Models/Components/EcommpayOptions.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The start date of the booking in ISO 8601 format (YYYY-MM-DD). Required for certain MCCs.
         /// </summary>
-        [JsonProperty("booking_start_date")]
-        public string? BookingStartDate { get; set; } = null;
+        [JsonProperty("booking_start_date", NullValueHandling = NullValueHandling.Include)]
+        public string? BookingStartDate
+        {
+            get => _bookingStartDate;
+            set
+            {
+                _bookingStartDate = value;
+                _bookingStartDateSet = true;
+            }
+        }
+
+        private string? _bookingStartDate = null;
+
+        private bool _bookingStartDateSet = false;
+
+        public bool ShouldSerializeBookingStartDate() => _bookingStartDateSet;
 
         /// <summary>
         /// The end date of the booking in ISO 8601 format (YYYY-MM-DD). Required for certain MCCs.
         /// </summary>
-        [JsonProperty("booking_end_date")]
-        public string? BookingEndDate { get; set; } = null;
+        [JsonProperty("booking_end_date", NullValueHandling = NullValueHandling.Include)]
+        public string? BookingEndDate
+        {
+            get => _bookingEndDate;
+            set
+            {
+                _bookingEndDate = value;
+                _bookingEndDateSet = true;
+            }
+        }
+
+        private string? _bookingEndDate = null;
+
+        private bool _bookingEndDateSet = false;
+
+        public bool ShouldSerializeBookingEndDate() => _bookingEndDateSet;
     }
 }

--- a/src/Gr4vy/Models/Components/FiservInstallmentOptions.cs
+++ b/src/Gr4vy/Models/Components/FiservInstallmentOptions.cs
@@ -17,25 +17,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes the `order.installmentOptions.numberOfInstallments` field to the Fiserv API.
         /// </summary>
-        [JsonProperty("numberOfInstallments")]
-        public long? NumberOfInstallments { get; set; } = null;
+        [JsonProperty("numberOfInstallments", NullValueHandling = NullValueHandling.Include)]
+        public long? NumberOfInstallments
+        {
+            get => _numberOfInstallments;
+            set
+            {
+                _numberOfInstallments = value;
+                _numberOfInstallmentsSet = true;
+            }
+        }
+
+        private long? _numberOfInstallments = null;
+
+        private bool _numberOfInstallmentsSet = false;
+
+        public bool ShouldSerializeNumberOfInstallments() => _numberOfInstallmentsSet;
 
         /// <summary>
         /// Passes the `order.installmentOptions.installmentsInterest` field to the Fiserv API.
         /// </summary>
-        [JsonProperty("installmentsInterest")]
-        public bool? InstallmentsInterest { get; set; } = null;
+        [JsonProperty("installmentsInterest", NullValueHandling = NullValueHandling.Include)]
+        public bool? InstallmentsInterest
+        {
+            get => _installmentsInterest;
+            set
+            {
+                _installmentsInterest = value;
+                _installmentsInterestSet = true;
+            }
+        }
+
+        private bool? _installmentsInterest = null;
+
+        private bool _installmentsInterestSet = false;
+
+        public bool ShouldSerializeInstallmentsInterest() => _installmentsInterestSet;
 
         /// <summary>
         /// Passes the `order.installmentOptions.installmentDelayMonths` field to the Fiserv API.
         /// </summary>
-        [JsonProperty("installmentDelayMonths")]
-        public long? InstallmentDelayMonths { get; set; } = null;
+        [JsonProperty("installmentDelayMonths", NullValueHandling = NullValueHandling.Include)]
+        public long? InstallmentDelayMonths
+        {
+            get => _installmentDelayMonths;
+            set
+            {
+                _installmentDelayMonths = value;
+                _installmentDelayMonthsSet = true;
+            }
+        }
+
+        private long? _installmentDelayMonths = null;
+
+        private bool _installmentDelayMonthsSet = false;
+
+        public bool ShouldSerializeInstallmentDelayMonths() => _installmentDelayMonthsSet;
 
         /// <summary>
         /// Passes the `order.installmentOptions.merchantAdviceCodeSupported` field to the Fiserv API.
         /// </summary>
-        [JsonProperty("merchantAdviceCodeSupported")]
-        public bool? MerchantAdviceCodeSupported { get; set; } = null;
+        [JsonProperty("merchantAdviceCodeSupported", NullValueHandling = NullValueHandling.Include)]
+        public bool? MerchantAdviceCodeSupported
+        {
+            get => _merchantAdviceCodeSupported;
+            set
+            {
+                _merchantAdviceCodeSupported = value;
+                _merchantAdviceCodeSupportedSet = true;
+            }
+        }
+
+        private bool? _merchantAdviceCodeSupported = null;
+
+        private bool _merchantAdviceCodeSupportedSet = false;
+
+        public bool ShouldSerializeMerchantAdviceCodeSupported() => _merchantAdviceCodeSupportedSet;
     }
 }

--- a/src/Gr4vy/Models/Components/FiservOptions.cs
+++ b/src/Gr4vy/Models/Components/FiservOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Passes installment data to the Fiserv API. This is now also a dedicated feature on the Gr4vy API.
         /// </summary>
-        [JsonProperty("installmentOptions")]
-        public FiservInstallmentOptions? InstallmentOptions { get; set; } = null;
+        [JsonProperty("installmentOptions", NullValueHandling = NullValueHandling.Include)]
+        public FiservInstallmentOptions? InstallmentOptions
+        {
+            get => _installmentOptions;
+            set
+            {
+                _installmentOptions = value;
+                _installmentOptionsSet = true;
+            }
+        }
+
+        private FiservInstallmentOptions? _installmentOptions = null;
+
+        private bool _installmentOptionsSet = false;
+
+        public bool ShouldSerializeInstallmentOptions() => _installmentOptionsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptions.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptions.cs
@@ -19,31 +19,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The delivery type.
         /// </summary>
-        [JsonProperty("delivery_type")]
-        public string? DeliveryType { get; set; } = null;
+        [JsonProperty("delivery_type", NullValueHandling = NullValueHandling.Include)]
+        public string? DeliveryType
+        {
+            get => _deliveryType;
+            set
+            {
+                _deliveryType = value;
+                _deliveryTypeSet = true;
+            }
+        }
+
+        private string? _deliveryType = null;
+
+        private bool _deliveryTypeSet = false;
+
+        public bool ShouldSerializeDeliveryType() => _deliveryTypeSet;
 
         /// <summary>
         /// The delivery method.
         /// </summary>
-        [JsonProperty("delivery_method")]
-        public string? DeliveryMethod { get; set; } = null;
+        [JsonProperty("delivery_method", NullValueHandling = NullValueHandling.Include)]
+        public string? DeliveryMethod
+        {
+            get => _deliveryMethod;
+            set
+            {
+                _deliveryMethod = value;
+                _deliveryMethodSet = true;
+            }
+        }
+
+        private string? _deliveryMethod = null;
+
+        private bool _deliveryMethodSet = false;
+
+        public bool ShouldSerializeDeliveryMethod() => _deliveryMethodSet;
 
         /// <summary>
         /// Defines if this payment is made using guest checkout.
         /// </summary>
-        [JsonProperty("is_guest_buyer")]
-        public bool? IsGuestBuyer { get; set; } = null;
+        [JsonProperty("is_guest_buyer", NullValueHandling = NullValueHandling.Include)]
+        public bool? IsGuestBuyer
+        {
+            get => _isGuestBuyer;
+            set
+            {
+                _isGuestBuyer = value;
+                _isGuestBuyerSet = true;
+            }
+        }
+
+        private bool? _isGuestBuyer = null;
+
+        private bool _isGuestBuyerSet = false;
+
+        public bool ShouldSerializeIsGuestBuyer() => _isGuestBuyerSet;
 
         /// <summary>
         /// A list of cart items details to pass to the Forter API.
         /// </summary>
-        [JsonProperty("cart_items")]
-        public List<ForterAntiFraudOptionsCartItem>? CartItems { get; set; } = null;
+        [JsonProperty("cart_items", NullValueHandling = NullValueHandling.Include)]
+        public List<ForterAntiFraudOptionsCartItem>? CartItems
+        {
+            get => _cartItems;
+            set
+            {
+                _cartItems = value;
+                _cartItemsSet = true;
+            }
+        }
+
+        private List<ForterAntiFraudOptionsCartItem>? _cartItems = null;
+
+        private bool _cartItemsSet = false;
+
+        public bool ShouldSerializeCartItems() => _cartItemsSet;
 
         /// <summary>
         /// Information about the discount applied to this order.
         /// </summary>
-        [JsonProperty("total_discount")]
-        public ForterAntiFraudOptionsDiscount? TotalDiscount { get; set; } = null;
+        [JsonProperty("total_discount", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsDiscount? TotalDiscount
+        {
+            get => _totalDiscount;
+            set
+            {
+                _totalDiscount = value;
+                _totalDiscountSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsDiscount? _totalDiscount = null;
+
+        private bool _totalDiscountSet = false;
+
+        public bool ShouldSerializeTotalDiscount() => _totalDiscountSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItem.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItem.cs
@@ -19,19 +19,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Basic information about the cart item.
         /// </summary>
-        [JsonProperty("basic_item_data")]
-        public ForterAntiFraudOptionsCartItemBasicItemData? BasicItemData { get; set; } = null;
+        [JsonProperty("basic_item_data", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsCartItemBasicItemData? BasicItemData
+        {
+            get => _basicItemData;
+            set
+            {
+                _basicItemData = value;
+                _basicItemDataSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsCartItemBasicItemData? _basicItemData = null;
+
+        private bool _basicItemDataSet = false;
+
+        public bool ShouldSerializeBasicItemData() => _basicItemDataSet;
 
         /// <summary>
         /// Details about how the item will be delivered.
         /// </summary>
-        [JsonProperty("delivery_details")]
-        public ForterAntiFraudOptionsCartItemDeliveryDetails? DeliveryDetails { get; set; } = null;
+        [JsonProperty("delivery_details", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsCartItemDeliveryDetails? DeliveryDetails
+        {
+            get => _deliveryDetails;
+            set
+            {
+                _deliveryDetails = value;
+                _deliveryDetailsSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsCartItemDeliveryDetails? _deliveryDetails = null;
+
+        private bool _deliveryDetailsSet = false;
+
+        public bool ShouldSerializeDeliveryDetails() => _deliveryDetailsSet;
 
         /// <summary>
         /// List of beneficiaries who will receive this item.
         /// </summary>
-        [JsonProperty("beneficiaries")]
-        public List<ForterAntiFraudOptionsCartItemBeneficiary>? Beneficiaries { get; set; } = null;
+        [JsonProperty("beneficiaries", NullValueHandling = NullValueHandling.Include)]
+        public List<ForterAntiFraudOptionsCartItemBeneficiary>? Beneficiaries
+        {
+            get => _beneficiaries;
+            set
+            {
+                _beneficiaries = value;
+                _beneficiariesSet = true;
+            }
+        }
+
+        private List<ForterAntiFraudOptionsCartItemBeneficiary>? _beneficiaries = null;
+
+        private bool _beneficiariesSet = false;
+
+        public bool ShouldSerializeBeneficiaries() => _beneficiariesSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBasicItemData.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBasicItemData.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates whether the item is a physical good or a service/digital item.
         /// </summary>
-        [JsonProperty("type")]
-        public string? Type { get; set; } = null;
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Include)]
+        public string? Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _typeSet = true;
+            }
+        }
+
+        private string? _type = null;
+
+        private bool _typeSet = false;
+
+        public bool ShouldSerializeType() => _typeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiary.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiary.cs
@@ -16,25 +16,81 @@ namespace Gr4vy.Models.Components
 
     public class ForterAntiFraudOptionsCartItemBeneficiary
     {
-        [JsonProperty("personal_details")]
-        public ForterAntiFraudOptionsCartItemBeneficiaryPersonalDetails PersonalDetails { get; set; } = default!;
+        [JsonProperty("personal_details", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsCartItemBeneficiaryPersonalDetails PersonalDetails
+        {
+            get => _personalDetails;
+            set
+            {
+                _personalDetails = value;
+                _personalDetailsSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsCartItemBeneficiaryPersonalDetails _personalDetails = default!;
+
+        private bool _personalDetailsSet = true;
+
+        public bool ShouldSerializePersonalDetails() => _personalDetailsSet;
 
         /// <summary>
         /// Address information of the beneficiary.
         /// </summary>
-        [JsonProperty("address")]
-        public ForterAntiFraudOptionsCartItemBeneficiaryAddress? Address { get; set; } = null;
+        [JsonProperty("address", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsCartItemBeneficiaryAddress? Address
+        {
+            get => _address;
+            set
+            {
+                _address = value;
+                _addressSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsCartItemBeneficiaryAddress? _address = null;
+
+        private bool _addressSet = false;
+
+        public bool ShouldSerializeAddress() => _addressSet;
 
         /// <summary>
         /// Phone numbers associated with the beneficiary.
         /// </summary>
-        [JsonProperty("phone")]
-        public List<ForterAntiFraudOptionsCartItemBeneficiaryPhone>? Phone { get; set; } = null;
+        [JsonProperty("phone", NullValueHandling = NullValueHandling.Include)]
+        public List<ForterAntiFraudOptionsCartItemBeneficiaryPhone>? Phone
+        {
+            get => _phone;
+            set
+            {
+                _phone = value;
+                _phoneSet = true;
+            }
+        }
+
+        private List<ForterAntiFraudOptionsCartItemBeneficiaryPhone>? _phone = null;
+
+        private bool _phoneSet = false;
+
+        public bool ShouldSerializePhone() => _phoneSet;
 
         /// <summary>
         /// Comments related to the beneficiary.
         /// </summary>
-        [JsonProperty("comments")]
-        public ForterAntiFraudOptionsCartItemBeneficiaryComments? Comments { get; set; } = null;
+        [JsonProperty("comments", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsCartItemBeneficiaryComments? Comments
+        {
+            get => _comments;
+            set
+            {
+                _comments = value;
+                _commentsSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsCartItemBeneficiaryComments? _comments = null;
+
+        private bool _commentsSet = false;
+
+        public bool ShouldSerializeComments() => _commentsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryAddress.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryAddress.cs
@@ -17,43 +17,141 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The country code of the beneficiary's address.
         /// </summary>
-        [JsonProperty("country")]
-        public string Country { get; set; } = default!;
+        [JsonProperty("country", NullValueHandling = NullValueHandling.Include)]
+        public string Country
+        {
+            get => _country;
+            set
+            {
+                _country = value;
+                _countrySet = true;
+            }
+        }
+
+        private string _country = default!;
+
+        private bool _countrySet = true;
+
+        public bool ShouldSerializeCountry() => _countrySet;
 
         /// <summary>
         /// First line of the beneficiary's address.
         /// </summary>
-        [JsonProperty("address1")]
-        public string? Address1 { get; set; } = null;
+        [JsonProperty("address1", NullValueHandling = NullValueHandling.Include)]
+        public string? Address1
+        {
+            get => _address1;
+            set
+            {
+                _address1 = value;
+                _address1Set = true;
+            }
+        }
+
+        private string? _address1 = null;
+
+        private bool _address1Set = false;
+
+        public bool ShouldSerializeAddress1() => _address1Set;
 
         /// <summary>
         /// Second line of the beneficiary's address.
         /// </summary>
-        [JsonProperty("address2")]
-        public string? Address2 { get; set; } = null;
+        [JsonProperty("address2", NullValueHandling = NullValueHandling.Include)]
+        public string? Address2
+        {
+            get => _address2;
+            set
+            {
+                _address2 = value;
+                _address2Set = true;
+            }
+        }
+
+        private string? _address2 = null;
+
+        private bool _address2Set = false;
+
+        public bool ShouldSerializeAddress2() => _address2Set;
 
         /// <summary>
         /// Zip or postal code of the beneficiary's address.
         /// </summary>
-        [JsonProperty("zip")]
-        public string? Zip { get; set; } = null;
+        [JsonProperty("zip", NullValueHandling = NullValueHandling.Include)]
+        public string? Zip
+        {
+            get => _zip;
+            set
+            {
+                _zip = value;
+                _zipSet = true;
+            }
+        }
+
+        private string? _zip = null;
+
+        private bool _zipSet = false;
+
+        public bool ShouldSerializeZip() => _zipSet;
 
         /// <summary>
         /// State or region of the beneficiary's address.
         /// </summary>
-        [JsonProperty("region")]
-        public string? Region { get; set; } = null;
+        [JsonProperty("region", NullValueHandling = NullValueHandling.Include)]
+        public string? Region
+        {
+            get => _region;
+            set
+            {
+                _region = value;
+                _regionSet = true;
+            }
+        }
+
+        private string? _region = null;
+
+        private bool _regionSet = false;
+
+        public bool ShouldSerializeRegion() => _regionSet;
 
         /// <summary>
         /// Company name associated with the beneficiary's address.
         /// </summary>
-        [JsonProperty("company")]
-        public string? Company { get; set; } = null;
+        [JsonProperty("company", NullValueHandling = NullValueHandling.Include)]
+        public string? Company
+        {
+            get => _company;
+            set
+            {
+                _company = value;
+                _companySet = true;
+            }
+        }
+
+        private string? _company = null;
+
+        private bool _companySet = false;
+
+        public bool ShouldSerializeCompany() => _companySet;
 
         /// <summary>
         /// City of the beneficiary's address.
         /// </summary>
-        [JsonProperty("city")]
-        public string? City { get; set; } = null;
+        [JsonProperty("city", NullValueHandling = NullValueHandling.Include)]
+        public string? City
+        {
+            get => _city;
+            set
+            {
+                _city = value;
+                _citySet = true;
+            }
+        }
+
+        private string? _city = null;
+
+        private bool _citySet = false;
+
+        public bool ShouldSerializeCity() => _citySet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryComments.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryComments.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Comments from the user to the merchant.
         /// </summary>
-        [JsonProperty("user_comments_to_merchant")]
-        public string? UserCommentsToMerchant { get; set; } = null;
+        [JsonProperty("user_comments_to_merchant", NullValueHandling = NullValueHandling.Include)]
+        public string? UserCommentsToMerchant
+        {
+            get => _userCommentsToMerchant;
+            set
+            {
+                _userCommentsToMerchant = value;
+                _userCommentsToMerchantSet = true;
+            }
+        }
+
+        private string? _userCommentsToMerchant = null;
+
+        private bool _userCommentsToMerchantSet = false;
+
+        public bool ShouldSerializeUserCommentsToMerchant() => _userCommentsToMerchantSet;
 
         /// <summary>
         /// Message intended for the beneficiary of the item.
         /// </summary>
-        [JsonProperty("message_to_beneficiary")]
-        public string? MessageToBeneficiary { get; set; } = null;
+        [JsonProperty("message_to_beneficiary", NullValueHandling = NullValueHandling.Include)]
+        public string? MessageToBeneficiary
+        {
+            get => _messageToBeneficiary;
+            set
+            {
+                _messageToBeneficiary = value;
+                _messageToBeneficiarySet = true;
+            }
+        }
+
+        private string? _messageToBeneficiary = null;
+
+        private bool _messageToBeneficiarySet = false;
+
+        public bool ShouldSerializeMessageToBeneficiary() => _messageToBeneficiarySet;
 
         /// <summary>
         /// Comments from the merchant about this transaction.
         /// </summary>
-        [JsonProperty("merchant_comments")]
-        public string? MerchantComments { get; set; } = null;
+        [JsonProperty("merchant_comments", NullValueHandling = NullValueHandling.Include)]
+        public string? MerchantComments
+        {
+            get => _merchantComments;
+            set
+            {
+                _merchantComments = value;
+                _merchantCommentsSet = true;
+            }
+        }
+
+        private string? _merchantComments = null;
+
+        private bool _merchantCommentsSet = false;
+
+        public bool ShouldSerializeMerchantComments() => _merchantCommentsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryPersonalDetails.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryPersonalDetails.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// First name of the beneficiary.
         /// </summary>
-        [JsonProperty("first_name")]
-        public string? FirstName { get; set; } = null;
+        [JsonProperty("first_name", NullValueHandling = NullValueHandling.Include)]
+        public string? FirstName
+        {
+            get => _firstName;
+            set
+            {
+                _firstName = value;
+                _firstNameSet = true;
+            }
+        }
+
+        private string? _firstName = null;
+
+        private bool _firstNameSet = false;
+
+        public bool ShouldSerializeFirstName() => _firstNameSet;
 
         /// <summary>
         /// Last name of the beneficiary.
         /// </summary>
-        [JsonProperty("last_name")]
-        public string? LastName { get; set; } = null;
+        [JsonProperty("last_name", NullValueHandling = NullValueHandling.Include)]
+        public string? LastName
+        {
+            get => _lastName;
+            set
+            {
+                _lastName = value;
+                _lastNameSet = true;
+            }
+        }
+
+        private string? _lastName = null;
+
+        private bool _lastNameSet = false;
+
+        public bool ShouldSerializeLastName() => _lastNameSet;
 
         /// <summary>
         /// Email address of the beneficiary.
         /// </summary>
-        [JsonProperty("email")]
-        public string? Email { get; set; } = null;
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Include)]
+        public string? Email
+        {
+            get => _email;
+            set
+            {
+                _email = value;
+                _emailSet = true;
+            }
+        }
+
+        private string? _email = null;
+
+        private bool _emailSet = false;
+
+        public bool ShouldSerializeEmail() => _emailSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryPhone.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemBeneficiaryPhone.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The phone number of the beneficiary.
         /// </summary>
-        [JsonProperty("phone")]
-        public string Phone { get; set; } = default!;
+        [JsonProperty("phone", NullValueHandling = NullValueHandling.Include)]
+        public string Phone
+        {
+            get => _phone;
+            set
+            {
+                _phone = value;
+                _phoneSet = true;
+            }
+        }
+
+        private string _phone = default!;
+
+        private bool _phoneSet = true;
+
+        public bool ShouldSerializePhone() => _phoneSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemDeliveryDetails.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsCartItemDeliveryDetails.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The type of delivery for this cart item.
         /// </summary>
-        [JsonProperty("delivery_type")]
-        public string? DeliveryType { get; set; } = null;
+        [JsonProperty("delivery_type", NullValueHandling = NullValueHandling.Include)]
+        public string? DeliveryType
+        {
+            get => _deliveryType;
+            set
+            {
+                _deliveryType = value;
+                _deliveryTypeSet = true;
+            }
+        }
+
+        private string? _deliveryType = null;
+
+        private bool _deliveryTypeSet = false;
+
+        public bool ShouldSerializeDeliveryType() => _deliveryTypeSet;
 
         /// <summary>
         /// The method of delivery for this cart item.
         /// </summary>
-        [JsonProperty("delivery_method")]
-        public string? DeliveryMethod { get; set; } = null;
+        [JsonProperty("delivery_method", NullValueHandling = NullValueHandling.Include)]
+        public string? DeliveryMethod
+        {
+            get => _deliveryMethod;
+            set
+            {
+                _deliveryMethod = value;
+                _deliveryMethodSet = true;
+            }
+        }
+
+        private string? _deliveryMethod = null;
+
+        private bool _deliveryMethodSet = false;
+
+        public bool ShouldSerializeDeliveryMethod() => _deliveryMethodSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsDiscount.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsDiscount.cs
@@ -18,25 +18,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The coupon code applied to the order.
         /// </summary>
-        [JsonProperty("coupon_code_used")]
-        public string CouponCodeUsed { get; set; } = default!;
+        [JsonProperty("coupon_code_used", NullValueHandling = NullValueHandling.Include)]
+        public string CouponCodeUsed
+        {
+            get => _couponCodeUsed;
+            set
+            {
+                _couponCodeUsed = value;
+                _couponCodeUsedSet = true;
+            }
+        }
+
+        private string _couponCodeUsed = default!;
+
+        private bool _couponCodeUsedSet = true;
+
+        public bool ShouldSerializeCouponCodeUsed() => _couponCodeUsedSet;
 
         /// <summary>
         /// The type of discount applied to the order.
         /// </summary>
-        [JsonProperty("discount_type")]
-        public string DiscountType { get; set; } = default!;
+        [JsonProperty("discount_type", NullValueHandling = NullValueHandling.Include)]
+        public string DiscountType
+        {
+            get => _discountType;
+            set
+            {
+                _discountType = value;
+                _discountTypeSet = true;
+            }
+        }
+
+        private string _discountType = default!;
+
+        private bool _discountTypeSet = true;
+
+        public bool ShouldSerializeDiscountType() => _discountTypeSet;
 
         /// <summary>
         /// Monetary details of the discount amount.
         /// </summary>
-        [JsonProperty("coupon_discount_amount")]
-        public ForterAntiFraudOptionsDiscountCouponDiscountAmount? CouponDiscountAmount { get; set; } = null;
+        [JsonProperty("coupon_discount_amount", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptionsDiscountCouponDiscountAmount? CouponDiscountAmount
+        {
+            get => _couponDiscountAmount;
+            set
+            {
+                _couponDiscountAmount = value;
+                _couponDiscountAmountSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptionsDiscountCouponDiscountAmount? _couponDiscountAmount = null;
+
+        private bool _couponDiscountAmountSet = false;
+
+        public bool ShouldSerializeCouponDiscountAmount() => _couponDiscountAmountSet;
 
         /// <summary>
         /// The percentage discount applied via the coupon.
         /// </summary>
-        [JsonProperty("coupon_discount_percent")]
-        public string? CouponDiscountPercent { get; set; } = null;
+        [JsonProperty("coupon_discount_percent", NullValueHandling = NullValueHandling.Include)]
+        public string? CouponDiscountPercent
+        {
+            get => _couponDiscountPercent;
+            set
+            {
+                _couponDiscountPercent = value;
+                _couponDiscountPercentSet = true;
+            }
+        }
+
+        private string? _couponDiscountPercent = null;
+
+        private bool _couponDiscountPercentSet = false;
+
+        public bool ShouldSerializeCouponDiscountPercent() => _couponDiscountPercentSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ForterAntiFraudOptionsDiscountCouponDiscountAmount.cs
+++ b/src/Gr4vy/Models/Components/ForterAntiFraudOptionsDiscountCouponDiscountAmount.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The discount amount in USD.
         /// </summary>
-        [JsonProperty("amount_usd")]
-        public string? AmountUsd { get; set; } = null;
+        [JsonProperty("amount_usd", NullValueHandling = NullValueHandling.Include)]
+        public string? AmountUsd
+        {
+            get => _amountUsd;
+            set
+            {
+                _amountUsd = value;
+                _amountUsdSet = true;
+            }
+        }
+
+        private string? _amountUsd = null;
+
+        private bool _amountUsdSet = false;
+
+        public bool ShouldSerializeAmountUsd() => _amountUsdSet;
 
         /// <summary>
         /// The discount amount in local currency.
         /// </summary>
-        [JsonProperty("amount_local_currency")]
-        public string? AmountLocalCurrency { get; set; } = null;
+        [JsonProperty("amount_local_currency", NullValueHandling = NullValueHandling.Include)]
+        public string? AmountLocalCurrency
+        {
+            get => _amountLocalCurrency;
+            set
+            {
+                _amountLocalCurrency = value;
+                _amountLocalCurrencySet = true;
+            }
+        }
+
+        private string? _amountLocalCurrency = null;
+
+        private bool _amountLocalCurrencySet = false;
+
+        public bool ShouldSerializeAmountLocalCurrency() => _amountLocalCurrencySet;
 
         /// <summary>
         /// The currency code for the discount amount.
         /// </summary>
-        [JsonProperty("currency")]
-        public string? Currency { get; set; } = null;
+        [JsonProperty("currency", NullValueHandling = NullValueHandling.Include)]
+        public string? Currency
+        {
+            get => _currency;
+            set
+            {
+                _currency = value;
+                _currencySet = true;
+            }
+        }
+
+        private string? _currency = null;
+
+        private bool _currencySet = false;
+
+        public bool ShouldSerializeCurrency() => _currencySet;
     }
 }

--- a/src/Gr4vy/Models/Components/GivingBlockOptions.cs
+++ b/src/Gr4vy/Models/Components/GivingBlockOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The default cryptocurrency to present at checkout. This can be used to ensure the user is presented with the same currency in both your checkout and the Giving Block checkout.
         /// </summary>
-        [JsonProperty("defaultCryptocurrency")]
-        public string? DefaultCryptocurrency { get; set; } = null;
+        [JsonProperty("defaultCryptocurrency", NullValueHandling = NullValueHandling.Include)]
+        public string? DefaultCryptocurrency
+        {
+            get => _defaultCryptocurrency;
+            set
+            {
+                _defaultCryptocurrency = value;
+                _defaultCryptocurrencySet = true;
+            }
+        }
+
+        private string? _defaultCryptocurrency = null;
+
+        private bool _defaultCryptocurrencySet = false;
+
+        public bool ShouldSerializeDefaultCryptocurrency() => _defaultCryptocurrencySet;
     }
 }

--- a/src/Gr4vy/Models/Components/GoCardlessOptions.cs
+++ b/src/Gr4vy/Models/Components/GoCardlessOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Specifies the high-level purpose of a mandate and/or payment using a set of pre-defined categories. Required for the PayTo scheme, optional for all others.
         /// </summary>
-        [JsonProperty("purpose_code")]
-        public string? PurposeCode { get; set; } = null;
+        [JsonProperty("purpose_code", NullValueHandling = NullValueHandling.Include)]
+        public string? PurposeCode
+        {
+            get => _purposeCode;
+            set
+            {
+                _purposeCode = value;
+                _purposeCodeSet = true;
+            }
+        }
+
+        private string? _purposeCode = null;
+
+        private bool _purposeCodeSet = false;
+
+        public bool ShouldSerializePurposeCode() => _purposeCodeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/LatitudeOptions.cs
+++ b/src/Gr4vy/Models/Components/LatitudeOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The `promotionReference` field passed to the purchase API.
         /// </summary>
-        [JsonProperty("promotion_reference")]
-        public string? PromotionReference { get; set; } = null;
+        [JsonProperty("promotion_reference", NullValueHandling = NullValueHandling.Include)]
+        public string? PromotionReference
+        {
+            get => _promotionReference;
+            set
+            {
+                _promotionReference = value;
+                _promotionReferenceSet = true;
+            }
+        }
+
+        private string? _promotionReference = null;
+
+        private bool _promotionReferenceSet = false;
+
+        public bool ShouldSerializePromotionReference() => _promotionReferenceSet;
     }
 }

--- a/src/Gr4vy/Models/Components/MattildaTapiOptions.cs
+++ b/src/Gr4vy/Models/Components/MattildaTapiOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Defines the date at which the payment will expire if not completed. Must be provided in ISO 8601 format `(YYYY-MM-DD`). If not specified, it defaults to 7 days in the future from the current date.
         /// </summary>
-        [JsonProperty("payment_method_expires_at")]
-        public string? PaymentMethodExpiresAt { get; set; } = null;
+        [JsonProperty("payment_method_expires_at", NullValueHandling = NullValueHandling.Include)]
+        public string? PaymentMethodExpiresAt
+        {
+            get => _paymentMethodExpiresAt;
+            set
+            {
+                _paymentMethodExpiresAt = value;
+                _paymentMethodExpiresAtSet = true;
+            }
+        }
+
+        private string? _paymentMethodExpiresAt = null;
+
+        private bool _paymentMethodExpiresAtSet = false;
+
+        public bool ShouldSerializePaymentMethodExpiresAt() => _paymentMethodExpiresAtSet;
     }
 }

--- a/src/Gr4vy/Models/Components/MerchantProfileScheme.cs
+++ b/src/Gr4vy/Models/Components/MerchantProfileScheme.cs
@@ -17,34 +17,118 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Acquirer BIN to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_acquirer_bin")]
-        public string MerchantAcquirerBin { get; set; } = default!;
+        [JsonProperty("merchant_acquirer_bin", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantAcquirerBin
+        {
+            get => _merchantAcquirerBin;
+            set
+            {
+                _merchantAcquirerBin = value;
+                _merchantAcquirerBinSet = true;
+            }
+        }
+
+        private string _merchantAcquirerBin = default!;
+
+        private bool _merchantAcquirerBinSet = true;
+
+        public bool ShouldSerializeMerchantAcquirerBin() => _merchantAcquirerBinSet;
 
         /// <summary>
         /// Merchant ID to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_acquirer_id")]
-        public string MerchantAcquirerId { get; set; } = default!;
+        [JsonProperty("merchant_acquirer_id", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantAcquirerId
+        {
+            get => _merchantAcquirerId;
+            set
+            {
+                _merchantAcquirerId = value;
+                _merchantAcquirerIdSet = true;
+            }
+        }
 
-        [JsonProperty("merchant_name")]
-        public string MerchantName { get; set; } = default!;
+        private string _merchantAcquirerId = default!;
+
+        private bool _merchantAcquirerIdSet = true;
+
+        public bool ShouldSerializeMerchantAcquirerId() => _merchantAcquirerIdSet;
+
+        [JsonProperty("merchant_name", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantName
+        {
+            get => _merchantName;
+            set
+            {
+                _merchantName = value;
+                _merchantNameSet = true;
+            }
+        }
+
+        private string _merchantName = default!;
+
+        private bool _merchantNameSet = true;
+
+        public bool ShouldSerializeMerchantName() => _merchantNameSet;
 
         /// <summary>
         /// The merchant's ISO 3166-1 numeric country code.
         /// </summary>
-        [JsonProperty("merchant_country_code")]
-        public string MerchantCountryCode { get; set; } = default!;
+        [JsonProperty("merchant_country_code", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantCountryCode
+        {
+            get => _merchantCountryCode;
+            set
+            {
+                _merchantCountryCode = value;
+                _merchantCountryCodeSet = true;
+            }
+        }
+
+        private string _merchantCountryCode = default!;
+
+        private bool _merchantCountryCodeSet = true;
+
+        public bool ShouldSerializeMerchantCountryCode() => _merchantCountryCodeSet;
 
         /// <summary>
         /// Merchant category code to use when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_category_code")]
-        public string MerchantCategoryCode { get; set; } = default!;
+        [JsonProperty("merchant_category_code", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantCategoryCode
+        {
+            get => _merchantCategoryCode;
+            set
+            {
+                _merchantCategoryCode = value;
+                _merchantCategoryCodeSet = true;
+            }
+        }
+
+        private string _merchantCategoryCode = default!;
+
+        private bool _merchantCategoryCodeSet = true;
+
+        public bool ShouldSerializeMerchantCategoryCode() => _merchantCategoryCodeSet;
 
         /// <summary>
         /// URL to send when calling 3DS through this scheme.
         /// </summary>
-        [JsonProperty("merchant_url")]
-        public string MerchantUrl { get; set; } = default!;
+        [JsonProperty("merchant_url", NullValueHandling = NullValueHandling.Include)]
+        public string MerchantUrl
+        {
+            get => _merchantUrl;
+            set
+            {
+                _merchantUrl = value;
+                _merchantUrlSet = true;
+            }
+        }
+
+        private string _merchantUrl = default!;
+
+        private bool _merchantUrlSet = true;
+
+        public bool ShouldSerializeMerchantUrl() => _merchantUrlSet;
     }
 }

--- a/src/Gr4vy/Models/Components/MockCardMerchantAdviceCodeOptions.cs
+++ b/src/Gr4vy/Models/Components/MockCardMerchantAdviceCodeOptions.cs
@@ -17,8 +17,22 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The MAC to return for this request.
         /// </summary>
-        [JsonProperty("result")]
-        public string? Result { get; set; } = null;
+        [JsonProperty("result", NullValueHandling = NullValueHandling.Include)]
+        public string? Result
+        {
+            get => _result;
+            set
+            {
+                _result = value;
+                _resultSet = true;
+            }
+        }
+
+        private string? _result = null;
+
+        private bool _resultSet = false;
+
+        public bool ShouldSerializeResult() => _resultSet;
 
         /// <summary>
         /// When set, the MAC is only returned if the card number matches this account number.

--- a/src/Gr4vy/Models/Components/MockCardOptions.cs
+++ b/src/Gr4vy/Models/Components/MockCardOptions.cs
@@ -18,13 +18,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Allows for mocking the merchant advice code.
         /// </summary>
-        [JsonProperty("merchant_advice_code")]
-        public MockCardMerchantAdviceCodeOptions? MerchantAdviceCode { get; set; } = null;
+        [JsonProperty("merchant_advice_code", NullValueHandling = NullValueHandling.Include)]
+        public MockCardMerchantAdviceCodeOptions? MerchantAdviceCode
+        {
+            get => _merchantAdviceCode;
+            set
+            {
+                _merchantAdviceCode = value;
+                _merchantAdviceCodeSet = true;
+            }
+        }
+
+        private MockCardMerchantAdviceCodeOptions? _merchantAdviceCode = null;
+
+        private bool _merchantAdviceCodeSet = false;
+
+        public bool ShouldSerializeMerchantAdviceCode() => _merchantAdviceCodeSet;
 
         /// <summary>
         /// When set to true, prevents retries on failed transactions.
         /// </summary>
-        [JsonProperty("skip_retry")]
-        public bool? SkipRetry { get; set; } = null;
+        [JsonProperty("skip_retry", NullValueHandling = NullValueHandling.Include)]
+        public bool? SkipRetry
+        {
+            get => _skipRetry;
+            set
+            {
+                _skipRetry = value;
+                _skipRetrySet = true;
+            }
+        }
+
+        private bool? _skipRetry = null;
+
+        private bool _skipRetrySet = false;
+
+        public bool ShouldSerializeSkipRetry() => _skipRetrySet;
     }
 }

--- a/src/Gr4vy/Models/Components/MonatoSpeiOptions.cs
+++ b/src/Gr4vy/Models/Components/MonatoSpeiOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Approval URL that will receive a charge payment method reference.
         /// </summary>
-        [JsonProperty("approval_url")]
-        public string ApprovalUrl { get; set; } = default!;
+        [JsonProperty("approval_url", NullValueHandling = NullValueHandling.Include)]
+        public string ApprovalUrl
+        {
+            get => _approvalUrl;
+            set
+            {
+                _approvalUrl = value;
+                _approvalUrlSet = true;
+            }
+        }
+
+        private string _approvalUrl = default!;
+
+        private bool _approvalUrlSet = true;
+
+        public bool ShouldSerializeApprovalUrl() => _approvalUrlSet;
     }
 }

--- a/src/Gr4vy/Models/Components/NuveiAirlineDataOptions.cs
+++ b/src/Gr4vy/Models/Components/NuveiAirlineDataOptions.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The seat class of the booking.
         /// </summary>
-        [JsonProperty("seatClass")]
-        public string? SeatClass { get; set; } = null;
+        [JsonProperty("seatClass", NullValueHandling = NullValueHandling.Include)]
+        public string? SeatClass
+        {
+            get => _seatClass;
+            set
+            {
+                _seatClass = value;
+                _seatClassSet = true;
+            }
+        }
+
+        private string? _seatClass = null;
+
+        private bool _seatClassSet = false;
+
+        public bool ShouldSerializeSeatClass() => _seatClassSet;
 
         /// <summary>
         /// Indicates whether the cardholder is also a passenger.
         /// </summary>
-        [JsonProperty("isCardholderTraveling")]
-        public bool? IsCardholderTraveling { get; set; } = null;
+        [JsonProperty("isCardholderTraveling", NullValueHandling = NullValueHandling.Include)]
+        public bool? IsCardholderTraveling
+        {
+            get => _isCardholderTraveling;
+            set
+            {
+                _isCardholderTraveling = value;
+                _isCardholderTravelingSet = true;
+            }
+        }
+
+        private bool? _isCardholderTraveling = null;
+
+        private bool _isCardholderTravelingSet = false;
+
+        public bool ShouldSerializeIsCardholderTraveling() => _isCardholderTravelingSet;
     }
 }

--- a/src/Gr4vy/Models/Components/NuveiIDealOptions.cs
+++ b/src/Gr4vy/Models/Components/NuveiIDealOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Additional data to be sent to Nuvei.
         /// </summary>
-        [JsonProperty("customData")]
-        public string? CustomData { get; set; } = null;
+        [JsonProperty("customData", NullValueHandling = NullValueHandling.Include)]
+        public string? CustomData
+        {
+            get => _customData;
+            set
+            {
+                _customData = value;
+                _customDataSet = true;
+            }
+        }
+
+        private string? _customData = null;
+
+        private bool _customDataSet = false;
+
+        public bool ShouldSerializeCustomData() => _customDataSet;
     }
 }

--- a/src/Gr4vy/Models/Components/NuveiKlarnaOptions.cs
+++ b/src/Gr4vy/Models/Components/NuveiKlarnaOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Additional data to be sent to Nuvei.
         /// </summary>
-        [JsonProperty("customData")]
-        public string? CustomData { get; set; } = null;
+        [JsonProperty("customData", NullValueHandling = NullValueHandling.Include)]
+        public string? CustomData
+        {
+            get => _customData;
+            set
+            {
+                _customData = value;
+                _customDataSet = true;
+            }
+        }
+
+        private string? _customData = null;
+
+        private bool _customDataSet = false;
+
+        public bool ShouldSerializeCustomData() => _customDataSet;
     }
 }

--- a/src/Gr4vy/Models/Components/NuveiOptions.cs
+++ b/src/Gr4vy/Models/Components/NuveiOptions.cs
@@ -18,13 +18,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// General data about the customer provided by the merchant.
         /// </summary>
-        [JsonProperty("customData")]
-        public string? CustomData { get; set; } = null;
+        [JsonProperty("customData", NullValueHandling = NullValueHandling.Include)]
+        public string? CustomData
+        {
+            get => _customData;
+            set
+            {
+                _customData = value;
+                _customDataSet = true;
+            }
+        }
+
+        private string? _customData = null;
+
+        private bool _customDataSet = false;
+
+        public bool ShouldSerializeCustomData() => _customDataSet;
 
         /// <summary>
         /// Provides additional airline data for Nuvei payments.
         /// </summary>
-        [JsonProperty("airlineData")]
-        public NuveiAirlineDataOptions? AirlineData { get; set; } = null;
+        [JsonProperty("airlineData", NullValueHandling = NullValueHandling.Include)]
+        public NuveiAirlineDataOptions? AirlineData
+        {
+            get => _airlineData;
+            set
+            {
+                _airlineData = value;
+                _airlineDataSet = true;
+            }
+        }
+
+        private NuveiAirlineDataOptions? _airlineData = null;
+
+        private bool _airlineDataSet = false;
+
+        public bool ShouldSerializeAirlineData() => _airlineDataSet;
     }
 }

--- a/src/Gr4vy/Models/Components/NuveiPSEOptions.cs
+++ b/src/Gr4vy/Models/Components/NuveiPSEOptions.cs
@@ -17,25 +17,81 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Customer type ("N" for persona natural, "J" for persona jurídica).
         /// </summary>
-        [JsonProperty("userType")]
-        public string? UserType { get; set; } = null;
+        [JsonProperty("userType", NullValueHandling = NullValueHandling.Include)]
+        public string? UserType
+        {
+            get => _userType;
+            set
+            {
+                _userType = value;
+                _userTypeSet = true;
+            }
+        }
+
+        private string? _userType = null;
+
+        private bool _userTypeSet = false;
+
+        public bool ShouldSerializeUserType() => _userTypeSet;
 
         /// <summary>
         /// Customer’s document type.
         /// </summary>
-        [JsonProperty("userFisNumber")]
-        public string? UserFisNumber { get; set; } = null;
+        [JsonProperty("userFisNumber", NullValueHandling = NullValueHandling.Include)]
+        public string? UserFisNumber
+        {
+            get => _userFisNumber;
+            set
+            {
+                _userFisNumber = value;
+                _userFisNumberSet = true;
+            }
+        }
+
+        private string? _userFisNumber = null;
+
+        private bool _userFisNumberSet = false;
+
+        public bool ShouldSerializeUserFisNumber() => _userFisNumberSet;
 
         /// <summary>
         /// Customer’s document number.
         /// </summary>
-        [JsonProperty("fiscalNumber")]
-        public string? FiscalNumber { get; set; } = null;
+        [JsonProperty("fiscalNumber", NullValueHandling = NullValueHandling.Include)]
+        public string? FiscalNumber
+        {
+            get => _fiscalNumber;
+            set
+            {
+                _fiscalNumber = value;
+                _fiscalNumberSet = true;
+            }
+        }
+
+        private string? _fiscalNumber = null;
+
+        private bool _fiscalNumberSet = false;
+
+        public bool ShouldSerializeFiscalNumber() => _fiscalNumberSet;
 
         /// <summary>
         /// The bank code of the selected bank.
         /// </summary>
-        [JsonProperty("bankCode")]
-        public string? BankCode { get; set; } = null;
+        [JsonProperty("bankCode", NullValueHandling = NullValueHandling.Include)]
+        public string? BankCode
+        {
+            get => _bankCode;
+            set
+            {
+                _bankCode = value;
+                _bankCodeSet = true;
+            }
+        }
+
+        private string? _bankCode = null;
+
+        private bool _bankCodeSet = false;
+
+        public bool ShouldSerializeBankCode() => _bankCodeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/OxxoOptions.cs
+++ b/src/Gr4vy/Models/Components/OxxoOptions.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Defines a custom expiration time (unix time) after which Oxxo payment requests are cancelled.
         /// </summary>
-        [JsonProperty("payment_method_expires_at")]
-        public long? PaymentMethodExpiresAt { get; set; } = null;
+        [JsonProperty("payment_method_expires_at", NullValueHandling = NullValueHandling.Include)]
+        public long? PaymentMethodExpiresAt
+        {
+            get => _paymentMethodExpiresAt;
+            set
+            {
+                _paymentMethodExpiresAt = value;
+                _paymentMethodExpiresAtSet = true;
+            }
+        }
+
+        private long? _paymentMethodExpiresAt = null;
+
+        private bool _paymentMethodExpiresAtSet = false;
+
+        public bool ShouldSerializePaymentMethodExpiresAt() => _paymentMethodExpiresAtSet;
 
         /// <summary>
         /// Approval URL that will receive a charge payment method reference.
         /// </summary>
-        [JsonProperty("approval_url")]
-        public string? ApprovalUrl { get; set; } = null;
+        [JsonProperty("approval_url", NullValueHandling = NullValueHandling.Include)]
+        public string? ApprovalUrl
+        {
+            get => _approvalUrl;
+            set
+            {
+                _approvalUrl = value;
+                _approvalUrlSet = true;
+            }
+        }
+
+        private string? _approvalUrl = null;
+
+        private bool _approvalUrlSet = false;
+
+        public bool ShouldSerializeApprovalUrl() => _approvalUrlSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaypalOptions.cs
+++ b/src/Gr4vy/Models/Components/PaypalOptions.cs
@@ -19,13 +19,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Additional Set Transaction Context Values (STC) to be sent to PayPal as part of the transaction.
         /// </summary>
-        [JsonProperty("additional_data")]
-        public List<Dictionary<string, string>>? AdditionalData { get; set; } = null;
+        [JsonProperty("additional_data", NullValueHandling = NullValueHandling.Include)]
+        public List<Dictionary<string, string>>? AdditionalData
+        {
+            get => _additionalData;
+            set
+            {
+                _additionalData = value;
+                _additionalDataSet = true;
+            }
+        }
+
+        private List<Dictionary<string, string>>? _additionalData = null;
+
+        private bool _additionalDataSet = false;
+
+        public bool ShouldSerializeAdditionalData() => _additionalDataSet;
 
         /// <summary>
         /// Shipping information to be passed to the PayPal API.
         /// </summary>
-        [JsonProperty("shipping")]
-        public PaypalShippingOptions? Shipping { get; set; } = null;
+        [JsonProperty("shipping", NullValueHandling = NullValueHandling.Include)]
+        public PaypalShippingOptions? Shipping
+        {
+            get => _shipping;
+            set
+            {
+                _shipping = value;
+                _shippingSet = true;
+            }
+        }
+
+        private PaypalShippingOptions? _shipping = null;
+
+        private bool _shippingSet = false;
+
+        public bool ShouldSerializeShipping() => _shippingSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaypalShippingOptions.cs
+++ b/src/Gr4vy/Models/Components/PaypalShippingOptions.cs
@@ -19,7 +19,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Shipping options that the payee or merchant offers to the payer to ship or pick up their items.
         /// </summary>
-        [JsonProperty("options")]
-        public List<PaypalShippingOptionsItem>? Options { get; set; } = null;
+        [JsonProperty("options", NullValueHandling = NullValueHandling.Include)]
+        public List<PaypalShippingOptionsItem>? Options
+        {
+            get => _options;
+            set
+            {
+                _options = value;
+                _optionsSet = true;
+            }
+        }
+
+        private List<PaypalShippingOptionsItem>? _options = null;
+
+        private bool _optionsSet = false;
+
+        public bool ShouldSerializeOptions() => _optionsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaypalShippingOptionsItem.cs
+++ b/src/Gr4vy/Models/Components/PaypalShippingOptionsItem.cs
@@ -18,31 +18,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// A unique ID that identifies a payer-selected shipping option.
         /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; } = default!;
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Include)]
+        public string Id
+        {
+            get => _id;
+            set
+            {
+                _id = value;
+                _idSet = true;
+            }
+        }
+
+        private string _id = default!;
+
+        private bool _idSet = true;
+
+        public bool ShouldSerializeId() => _idSet;
 
         /// <summary>
         /// A description that the payer sees, which helps them choose an appropriate shipping option.
         /// </summary>
-        [JsonProperty("label")]
-        public string Label { get; set; } = default!;
+        [JsonProperty("label", NullValueHandling = NullValueHandling.Include)]
+        public string Label
+        {
+            get => _label;
+            set
+            {
+                _label = value;
+                _labelSet = true;
+            }
+        }
+
+        private string _label = default!;
+
+        private bool _labelSet = true;
+
+        public bool ShouldSerializeLabel() => _labelSet;
 
         /// <summary>
         /// If the API request sets selected = true, it represents the shipping option that the payee or merchant expects to be pre-selected for the payer when they first view the shipping.options in the PayPal Checkout experience. Only one shipping.option can be set to selected=true.
         /// </summary>
-        [JsonProperty("selected")]
-        public bool Selected { get; set; } = default!;
+        [JsonProperty("selected", NullValueHandling = NullValueHandling.Include)]
+        public bool Selected
+        {
+            get => _selected;
+            set
+            {
+                _selected = value;
+                _selectedSet = true;
+            }
+        }
+
+        private bool _selected = default!;
+
+        private bool _selectedSet = true;
+
+        public bool ShouldSerializeSelected() => _selectedSet;
 
         /// <summary>
         /// A classification for the method of purchase fulfillment.
         /// </summary>
-        [JsonProperty("type")]
-        public string? Type { get; set; } = null;
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Include)]
+        public string? Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _typeSet = true;
+            }
+        }
+
+        private string? _type = null;
+
+        private bool _typeSet = false;
+
+        public bool ShouldSerializeType() => _typeSet;
 
         /// <summary>
         /// The shipping cost for the selected option.
         /// </summary>
-        [JsonProperty("amount")]
-        public PaypalShippingOptionsItemAmount? Amount { get; set; } = null;
+        [JsonProperty("amount", NullValueHandling = NullValueHandling.Include)]
+        public PaypalShippingOptionsItemAmount? Amount
+        {
+            get => _amount;
+            set
+            {
+                _amount = value;
+                _amountSet = true;
+            }
+        }
+
+        private PaypalShippingOptionsItemAmount? _amount = null;
+
+        private bool _amountSet = false;
+
+        public bool ShouldSerializeAmount() => _amountSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PaypalShippingOptionsItemAmount.cs
+++ b/src/Gr4vy/Models/Components/PaypalShippingOptionsItemAmount.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The three-character ISO currency code.
         /// </summary>
-        [JsonProperty("currency_code")]
-        public string CurrencyCode { get; set; } = default!;
+        [JsonProperty("currency_code", NullValueHandling = NullValueHandling.Include)]
+        public string CurrencyCode
+        {
+            get => _currencyCode;
+            set
+            {
+                _currencyCode = value;
+                _currencyCodeSet = true;
+            }
+        }
+
+        private string _currencyCode = default!;
+
+        private bool _currencyCodeSet = true;
+
+        public bool ShouldSerializeCurrencyCode() => _currencyCodeSet;
 
         /// <summary>
         /// The amount value, which might include a decimal portion.
         /// </summary>
-        [JsonProperty("value")]
-        public string Value { get; set; } = default!;
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
+
+        private string _value = default!;
+
+        private bool _valueSet = true;
+
+        public bool ShouldSerializeValue() => _valueSet;
     }
 }

--- a/src/Gr4vy/Models/Components/PowertranzOptions.cs
+++ b/src/Gr4vy/Models/Components/PowertranzOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates to PowerTranz whether to skip the 3DS authentication for this transaction.
         /// </summary>
-        [JsonProperty("skipThreeDSecure")]
-        public bool? SkipThreeDSecure { get; set; } = null;
+        [JsonProperty("skipThreeDSecure", NullValueHandling = NullValueHandling.Include)]
+        public bool? SkipThreeDSecure
+        {
+            get => _skipThreeDSecure;
+            set
+            {
+                _skipThreeDSecure = value;
+                _skipThreeDSecureSet = true;
+            }
+        }
+
+        private bool? _skipThreeDSecure = null;
+
+        private bool _skipThreeDSecureSet = false;
+
+        public bool ShouldSerializeSkipThreeDSecure() => _skipThreeDSecureSet;
     }
 }

--- a/src/Gr4vy/Models/Components/RiskifiedAntiFraudOptions.cs
+++ b/src/Gr4vy/Models/Components/RiskifiedAntiFraudOptions.cs
@@ -19,7 +19,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// A list of line items details to override when passing to the Riskified API.
         /// </summary>
-        [JsonProperty("line_items")]
-        public List<RiskifiedAntiFraudOptionsLineItem>? LineItems { get; set; } = null;
+        [JsonProperty("line_items", NullValueHandling = NullValueHandling.Include)]
+        public List<RiskifiedAntiFraudOptionsLineItem>? LineItems
+        {
+            get => _lineItems;
+            set
+            {
+                _lineItems = value;
+                _lineItemsSet = true;
+            }
+        }
+
+        private List<RiskifiedAntiFraudOptionsLineItem>? _lineItems = null;
+
+        private bool _lineItemsSet = false;
+
+        public bool ShouldSerializeLineItems() => _lineItemsSet;
     }
 }

--- a/src/Gr4vy/Models/Components/RiskifiedAntiFraudOptionsLineItem.cs
+++ b/src/Gr4vy/Models/Components/RiskifiedAntiFraudOptionsLineItem.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates whether the item will be shipped or picked up.
         /// </summary>
-        [JsonProperty("delivered_to")]
-        public string? DeliveredTo { get; set; } = null;
+        [JsonProperty("delivered_to", NullValueHandling = NullValueHandling.Include)]
+        public string? DeliveredTo
+        {
+            get => _deliveredTo;
+            set
+            {
+                _deliveredTo = value;
+                _deliveredToSet = true;
+            }
+        }
+
+        private string? _deliveredTo = null;
+
+        private bool _deliveredToSet = false;
+
+        public bool ShouldSerializeDeliveredTo() => _deliveredToSet;
     }
 }

--- a/src/Gr4vy/Models/Components/StripeCardOptions.cs
+++ b/src/Gr4vy/Models/Components/StripeCardOptions.cs
@@ -18,13 +18,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Stripe options to support Stripe Connect.
         /// </summary>
-        [JsonProperty("stripe_connect")]
-        public StripeConnectOptions? StripeConnect { get; set; } = null;
+        [JsonProperty("stripe_connect", NullValueHandling = NullValueHandling.Include)]
+        public StripeConnectOptions? StripeConnect
+        {
+            get => _stripeConnect;
+            set
+            {
+                _stripeConnect = value;
+                _stripeConnectSet = true;
+            }
+        }
+
+        private StripeConnectOptions? _stripeConnect = null;
+
+        private bool _stripeConnectSet = false;
+
+        public bool ShouldSerializeStripeConnect() => _stripeConnectSet;
 
         /// <summary>
         /// Passes the `error_on_requires_action` option to the Stripe API. Set to true to fail the payment attempt if it transitions into requires_action. Use this parameter for simpler integrations that don't handle customer actions, such as saving cards without authentication.
         /// </summary>
-        [JsonProperty("error_on_requires_action")]
-        public bool? ErrorOnRequiresAction { get; set; } = null;
+        [JsonProperty("error_on_requires_action", NullValueHandling = NullValueHandling.Include)]
+        public bool? ErrorOnRequiresAction
+        {
+            get => _errorOnRequiresAction;
+            set
+            {
+                _errorOnRequiresAction = value;
+                _errorOnRequiresActionSet = true;
+            }
+        }
+
+        private bool? _errorOnRequiresAction = null;
+
+        private bool _errorOnRequiresActionSet = false;
+
+        public bool ShouldSerializeErrorOnRequiresAction() => _errorOnRequiresActionSet;
     }
 }

--- a/src/Gr4vy/Models/Components/StripeConnectOptions.cs
+++ b/src/Gr4vy/Models/Components/StripeConnectOptions.cs
@@ -17,31 +17,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The Stripe Connect account to target using the `Stripe-Account` header.
         /// </summary>
-        [JsonProperty("stripe_account")]
-        public string? StripeAccount { get; set; } = null;
+        [JsonProperty("stripe_account", NullValueHandling = NullValueHandling.Include)]
+        public string? StripeAccount
+        {
+            get => _stripeAccount;
+            set
+            {
+                _stripeAccount = value;
+                _stripeAccountSet = true;
+            }
+        }
+
+        private string? _stripeAccount = null;
+
+        private bool _stripeAccountSet = false;
+
+        public bool ShouldSerializeStripeAccount() => _stripeAccountSet;
 
         /// <summary>
         /// The fee to charge the connected account.
         /// </summary>
-        [JsonProperty("application_fee_amount")]
-        public long? ApplicationFeeAmount { get; set; } = null;
+        [JsonProperty("application_fee_amount", NullValueHandling = NullValueHandling.Include)]
+        public long? ApplicationFeeAmount
+        {
+            get => _applicationFeeAmount;
+            set
+            {
+                _applicationFeeAmount = value;
+                _applicationFeeAmountSet = true;
+            }
+        }
+
+        private long? _applicationFeeAmount = null;
+
+        private bool _applicationFeeAmountSet = false;
+
+        public bool ShouldSerializeApplicationFeeAmount() => _applicationFeeAmountSet;
 
         /// <summary>
         /// The Stripe Connect account to target using the `on_behalf_of` request parameter.
         /// </summary>
-        [JsonProperty("on_behalf_of")]
-        public string? OnBehalfOf { get; set; } = null;
+        [JsonProperty("on_behalf_of", NullValueHandling = NullValueHandling.Include)]
+        public string? OnBehalfOf
+        {
+            get => _onBehalfOf;
+            set
+            {
+                _onBehalfOf = value;
+                _onBehalfOfSet = true;
+            }
+        }
+
+        private string? _onBehalfOf = null;
+
+        private bool _onBehalfOfSet = false;
+
+        public bool ShouldSerializeOnBehalfOf() => _onBehalfOfSet;
 
         /// <summary>
         /// The Stripe Connect account to target using the `transfer_data.destination` request parameter.
         /// </summary>
-        [JsonProperty("transfer_data_destination")]
-        public string? TransferDataDestination { get; set; } = null;
+        [JsonProperty("transfer_data_destination", NullValueHandling = NullValueHandling.Include)]
+        public string? TransferDataDestination
+        {
+            get => _transferDataDestination;
+            set
+            {
+                _transferDataDestination = value;
+                _transferDataDestinationSet = true;
+            }
+        }
+
+        private string? _transferDataDestination = null;
+
+        private bool _transferDataDestinationSet = false;
+
+        public bool ShouldSerializeTransferDataDestination() => _transferDataDestinationSet;
 
         /// <summary>
         /// A string that identifies the payment as part of a group.
         /// </summary>
-        [JsonProperty("transfer_group")]
-        public string? TransferGroup { get; set; } = null;
+        [JsonProperty("transfer_group", NullValueHandling = NullValueHandling.Include)]
+        public string? TransferGroup
+        {
+            get => _transferGroup;
+            set
+            {
+                _transferGroup = value;
+                _transferGroupSet = true;
+            }
+        }
+
+        private string? _transferGroup = null;
+
+        private bool _transferGroupSet = false;
+
+        public bool ShouldSerializeTransferGroup() => _transferGroupSet;
     }
 }

--- a/src/Gr4vy/Models/Components/StripeOptions.cs
+++ b/src/Gr4vy/Models/Components/StripeOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Stripe options to support Stripe Connect.
         /// </summary>
-        [JsonProperty("stripe_connect")]
-        public StripeConnectOptions? StripeConnect { get; set; } = null;
+        [JsonProperty("stripe_connect", NullValueHandling = NullValueHandling.Include)]
+        public StripeConnectOptions? StripeConnect
+        {
+            get => _stripeConnect;
+            set
+            {
+                _stripeConnect = value;
+                _stripeConnectSet = true;
+            }
+        }
+
+        private StripeConnectOptions? _stripeConnect = null;
+
+        private bool _stripeConnectSet = false;
+
+        public bool ShouldSerializeStripeConnect() => _stripeConnectSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TaxId.cs
+++ b/src/Gr4vy/Models/Components/TaxId.cs
@@ -17,10 +17,38 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The tax ID for the buyer.
         /// </summary>
-        [JsonProperty("value")]
-        public string Value { get; set; } = default!;
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
 
-        [JsonProperty("kind")]
-        public string Kind { get; set; } = default!;
+        private string _value = default!;
+
+        private bool _valueSet = true;
+
+        public bool ShouldSerializeValue() => _valueSet;
+
+        [JsonProperty("kind", NullValueHandling = NullValueHandling.Include)]
+        public string Kind
+        {
+            get => _kind;
+            set
+            {
+                _kind = value;
+                _kindSet = true;
+            }
+        }
+
+        private string _kind = default!;
+
+        private bool _kindSet = true;
+
+        public bool ShouldSerializeKind() => _kindSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ThreeDSecureScenarioConditions.cs
+++ b/src/Gr4vy/Models/Components/ThreeDSecureScenarioConditions.cs
@@ -17,37 +17,121 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// First name of the buyer to match.
         /// </summary>
-        [JsonProperty("first_name")]
-        public string? FirstName { get; set; } = null;
+        [JsonProperty("first_name", NullValueHandling = NullValueHandling.Include)]
+        public string? FirstName
+        {
+            get => _firstName;
+            set
+            {
+                _firstName = value;
+                _firstNameSet = true;
+            }
+        }
+
+        private string? _firstName = null;
+
+        private bool _firstNameSet = false;
+
+        public bool ShouldSerializeFirstName() => _firstNameSet;
 
         /// <summary>
         /// Last name of the buyer to match.
         /// </summary>
-        [JsonProperty("last_name")]
-        public string? LastName { get; set; } = null;
+        [JsonProperty("last_name", NullValueHandling = NullValueHandling.Include)]
+        public string? LastName
+        {
+            get => _lastName;
+            set
+            {
+                _lastName = value;
+                _lastNameSet = true;
+            }
+        }
+
+        private string? _lastName = null;
+
+        private bool _lastNameSet = false;
+
+        public bool ShouldSerializeLastName() => _lastNameSet;
 
         /// <summary>
         /// Email address of the buyer to match.
         /// </summary>
-        [JsonProperty("email_address")]
-        public string? EmailAddress { get; set; } = null;
+        [JsonProperty("email_address", NullValueHandling = NullValueHandling.Include)]
+        public string? EmailAddress
+        {
+            get => _emailAddress;
+            set
+            {
+                _emailAddress = value;
+                _emailAddressSet = true;
+            }
+        }
+
+        private string? _emailAddress = null;
+
+        private bool _emailAddressSet = false;
+
+        public bool ShouldSerializeEmailAddress() => _emailAddressSet;
 
         /// <summary>
         /// Amount of the transaction to match.
         /// </summary>
-        [JsonProperty("amount")]
-        public long? Amount { get; set; } = null;
+        [JsonProperty("amount", NullValueHandling = NullValueHandling.Include)]
+        public long? Amount
+        {
+            get => _amount;
+            set
+            {
+                _amount = value;
+                _amountSet = true;
+            }
+        }
+
+        private long? _amount = null;
+
+        private bool _amountSet = false;
+
+        public bool ShouldSerializeAmount() => _amountSet;
 
         /// <summary>
         /// External identifier to match.
         /// </summary>
-        [JsonProperty("external_identifier")]
-        public string? ExternalIdentifier { get; set; } = null;
+        [JsonProperty("external_identifier", NullValueHandling = NullValueHandling.Include)]
+        public string? ExternalIdentifier
+        {
+            get => _externalIdentifier;
+            set
+            {
+                _externalIdentifier = value;
+                _externalIdentifierSet = true;
+            }
+        }
+
+        private string? _externalIdentifier = null;
+
+        private bool _externalIdentifierSet = false;
+
+        public bool ShouldSerializeExternalIdentifier() => _externalIdentifierSet;
 
         /// <summary>
         /// Card number to match.
         /// </summary>
-        [JsonProperty("card_number")]
-        public string? CardNumber { get; set; } = null;
+        [JsonProperty("card_number", NullValueHandling = NullValueHandling.Include)]
+        public string? CardNumber
+        {
+            get => _cardNumber;
+            set
+            {
+                _cardNumber = value;
+                _cardNumberSet = true;
+            }
+        }
+
+        private string? _cardNumber = null;
+
+        private bool _cardNumberSet = false;
+
+        public bool ShouldSerializeCardNumber() => _cardNumberSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcome.cs
+++ b/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcome.cs
@@ -18,16 +18,58 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The version of 3DS which will be simulated.
         /// </summary>
-        [JsonProperty("version")]
-        public string? Version { get; set; } = null;
+        [JsonProperty("version", NullValueHandling = NullValueHandling.Include)]
+        public string? Version
+        {
+            get => _version;
+            set
+            {
+                _version = value;
+                _versionSet = true;
+            }
+        }
 
-        [JsonProperty("authentication")]
-        public ThreeDSecureScenarioOutcomeAuthentication Authentication { get; set; } = default!;
+        private string? _version = null;
+
+        private bool _versionSet = false;
+
+        public bool ShouldSerializeVersion() => _versionSet;
+
+        [JsonProperty("authentication", NullValueHandling = NullValueHandling.Include)]
+        public ThreeDSecureScenarioOutcomeAuthentication Authentication
+        {
+            get => _authentication;
+            set
+            {
+                _authentication = value;
+                _authenticationSet = true;
+            }
+        }
+
+        private ThreeDSecureScenarioOutcomeAuthentication _authentication = default!;
+
+        private bool _authenticationSet = true;
+
+        public bool ShouldSerializeAuthentication() => _authenticationSet;
 
         /// <summary>
         /// 3DS result value. Required if authentication status is "C".
         /// </summary>
-        [JsonProperty("result")]
-        public ThreeDSecureScenarioOutcomeResult? Result { get; set; } = null;
+        [JsonProperty("result", NullValueHandling = NullValueHandling.Include)]
+        public ThreeDSecureScenarioOutcomeResult? Result
+        {
+            get => _result;
+            set
+            {
+                _result = value;
+                _resultSet = true;
+            }
+        }
+
+        private ThreeDSecureScenarioOutcomeResult? _result = null;
+
+        private bool _resultSet = false;
+
+        public bool ShouldSerializeResult() => _resultSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcomeAuthentication.cs
+++ b/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcomeAuthentication.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// 3DS transaction status.
         /// </summary>
-        [JsonProperty("transaction_status")]
-        public string TransactionStatus { get; set; } = default!;
+        [JsonProperty("transaction_status", NullValueHandling = NullValueHandling.Include)]
+        public string TransactionStatus
+        {
+            get => _transactionStatus;
+            set
+            {
+                _transactionStatus = value;
+                _transactionStatusSet = true;
+            }
+        }
+
+        private string _transactionStatus = default!;
+
+        private bool _transactionStatusSet = true;
+
+        public bool ShouldSerializeTransactionStatus() => _transactionStatusSet;
     }
 }

--- a/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcomeResult.cs
+++ b/src/Gr4vy/Models/Components/ThreeDSecureScenarioOutcomeResult.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// 3DS result.
         /// </summary>
-        [JsonProperty("transaction_status")]
-        public string TransactionStatus { get; set; } = default!;
+        [JsonProperty("transaction_status", NullValueHandling = NullValueHandling.Include)]
+        public string TransactionStatus
+        {
+            get => _transactionStatus;
+            set
+            {
+                _transactionStatus = value;
+                _transactionStatusSet = true;
+            }
+        }
+
+        private string _transactionStatus = default!;
+
+        private bool _transactionStatusSet = true;
+
+        public bool ShouldSerializeTransactionStatus() => _transactionStatusSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TransactionConnectionOptions.cs
+++ b/src/Gr4vy/Models/Components/TransactionConnectionOptions.cs
@@ -18,331 +18,1101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Custom options to be passed to the `account-updater` connector, allowing for simulating different account updater responses.
         /// </summary>
-        [JsonProperty("account-updater")]
-        public AccountUpdaterOptions? AccountUpdater { get; set; } = null;
+        [JsonProperty("account-updater", NullValueHandling = NullValueHandling.Include)]
+        public AccountUpdaterOptions? AccountUpdater
+        {
+            get => _accountUpdater;
+            set
+            {
+                _accountUpdater = value;
+                _accountUpdaterSet = true;
+            }
+        }
+
+        private AccountUpdaterOptions? _accountUpdater = null;
+
+        private bool _accountUpdaterSet = false;
+
+        public bool ShouldSerializeAccountUpdater() => _accountUpdaterSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-afterpay` connector.
         /// </summary>
-        [JsonProperty("adyen-afterpay")]
-        public AdyenOptions? AdyenAfterpay { get; set; } = null;
+        [JsonProperty("adyen-afterpay", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenAfterpay
+        {
+            get => _adyenAfterpay;
+            set
+            {
+                _adyenAfterpay = value;
+                _adyenAfterpaySet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenAfterpay = null;
+
+        private bool _adyenAfterpaySet = false;
+
+        public bool ShouldSerializeAdyenAfterpay() => _adyenAfterpaySet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-alipay` connector.
         /// </summary>
-        [JsonProperty("adyen-alipay")]
-        public AdyenOptions? AdyenAlipay { get; set; } = null;
+        [JsonProperty("adyen-alipay", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenAlipay
+        {
+            get => _adyenAlipay;
+            set
+            {
+                _adyenAlipay = value;
+                _adyenAlipaySet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenAlipay = null;
+
+        private bool _adyenAlipaySet = false;
+
+        public bool ShouldSerializeAdyenAlipay() => _adyenAlipaySet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-card` connector.
         /// </summary>
-        [JsonProperty("adyen-card")]
-        public AdyenCardOptions? AdyenCard { get; set; } = null;
+        [JsonProperty("adyen-card", NullValueHandling = NullValueHandling.Include)]
+        public AdyenCardOptions? AdyenCard
+        {
+            get => _adyenCard;
+            set
+            {
+                _adyenCard = value;
+                _adyenCardSet = true;
+            }
+        }
+
+        private AdyenCardOptions? _adyenCard = null;
+
+        private bool _adyenCardSet = false;
+
+        public bool ShouldSerializeAdyenCard() => _adyenCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-cashapp` connector.
         /// </summary>
-        [JsonProperty("adyen-cashapp")]
-        public AdyenOptions? AdyenCashapp { get; set; } = null;
+        [JsonProperty("adyen-cashapp", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenCashapp
+        {
+            get => _adyenCashapp;
+            set
+            {
+                _adyenCashapp = value;
+                _adyenCashappSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenCashapp = null;
+
+        private bool _adyenCashappSet = false;
+
+        public bool ShouldSerializeAdyenCashapp() => _adyenCashappSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-gcash` connector.
         /// </summary>
-        [JsonProperty("adyen-gcash")]
-        public AdyenOptions? AdyenGcash { get; set; } = null;
+        [JsonProperty("adyen-gcash", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenGcash
+        {
+            get => _adyenGcash;
+            set
+            {
+                _adyenGcash = value;
+                _adyenGcashSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenGcash = null;
+
+        private bool _adyenGcashSet = false;
+
+        public bool ShouldSerializeAdyenGcash() => _adyenGcashSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-giropay` connector.
         /// </summary>
-        [JsonProperty("adyen-giropay")]
-        public AdyenOptions? AdyenGiropay { get; set; } = null;
+        [JsonProperty("adyen-giropay", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenGiropay
+        {
+            get => _adyenGiropay;
+            set
+            {
+                _adyenGiropay = value;
+                _adyenGiropaySet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenGiropay = null;
+
+        private bool _adyenGiropaySet = false;
+
+        public bool ShouldSerializeAdyenGiropay() => _adyenGiropaySet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-ideal` connector.
         /// </summary>
-        [JsonProperty("adyen-ideal")]
-        public AdyenOptions? AdyenIdeal { get; set; } = null;
+        [JsonProperty("adyen-ideal", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenIdeal
+        {
+            get => _adyenIdeal;
+            set
+            {
+                _adyenIdeal = value;
+                _adyenIdealSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenIdeal = null;
+
+        private bool _adyenIdealSet = false;
+
+        public bool ShouldSerializeAdyenIdeal() => _adyenIdealSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-paypay` connector.
         /// </summary>
-        [JsonProperty("adyen-paypay")]
-        public AdyenOptions? AdyenPaypay { get; set; } = null;
+        [JsonProperty("adyen-paypay", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenPaypay
+        {
+            get => _adyenPaypay;
+            set
+            {
+                _adyenPaypay = value;
+                _adyenPaypaySet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenPaypay = null;
+
+        private bool _adyenPaypaySet = false;
+
+        public bool ShouldSerializeAdyenPaypay() => _adyenPaypaySet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-pix` connector.
         /// </summary>
-        [JsonProperty("adyen-pix")]
-        public AdyenPixOptions? AdyenPix { get; set; } = null;
+        [JsonProperty("adyen-pix", NullValueHandling = NullValueHandling.Include)]
+        public AdyenPixOptions? AdyenPix
+        {
+            get => _adyenPix;
+            set
+            {
+                _adyenPix = value;
+                _adyenPixSet = true;
+            }
+        }
+
+        private AdyenPixOptions? _adyenPix = null;
+
+        private bool _adyenPixSet = false;
+
+        public bool ShouldSerializeAdyenPix() => _adyenPixSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-sepa` connector.
         /// </summary>
-        [JsonProperty("adyen-sepa")]
-        public AdyenSepaOptions? AdyenSepa { get; set; } = null;
+        [JsonProperty("adyen-sepa", NullValueHandling = NullValueHandling.Include)]
+        public AdyenSepaOptions? AdyenSepa
+        {
+            get => _adyenSepa;
+            set
+            {
+                _adyenSepa = value;
+                _adyenSepaSet = true;
+            }
+        }
+
+        private AdyenSepaOptions? _adyenSepa = null;
+
+        private bool _adyenSepaSet = false;
+
+        public bool ShouldSerializeAdyenSepa() => _adyenSepaSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-sofort` connector.
         /// </summary>
-        [JsonProperty("adyen-sofort")]
-        public AdyenOptions? AdyenSofort { get; set; } = null;
+        [JsonProperty("adyen-sofort", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenSofort
+        {
+            get => _adyenSofort;
+            set
+            {
+                _adyenSofort = value;
+                _adyenSofortSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenSofort = null;
+
+        private bool _adyenSofortSet = false;
+
+        public bool ShouldSerializeAdyenSofort() => _adyenSofortSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-swish` connector.
         /// </summary>
-        [JsonProperty("adyen-swish")]
-        public AdyenOptions? AdyenSwish { get; set; } = null;
+        [JsonProperty("adyen-swish", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenSwish
+        {
+            get => _adyenSwish;
+            set
+            {
+                _adyenSwish = value;
+                _adyenSwishSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenSwish = null;
+
+        private bool _adyenSwishSet = false;
+
+        public bool ShouldSerializeAdyenSwish() => _adyenSwishSet;
 
         /// <summary>
         /// Custom options to be passed to the `adyen-vipps` connector.
         /// </summary>
-        [JsonProperty("adyen-vipps")]
-        public AdyenOptions? AdyenVipps { get; set; } = null;
+        [JsonProperty("adyen-vipps", NullValueHandling = NullValueHandling.Include)]
+        public AdyenOptions? AdyenVipps
+        {
+            get => _adyenVipps;
+            set
+            {
+                _adyenVipps = value;
+                _adyenVippsSet = true;
+            }
+        }
+
+        private AdyenOptions? _adyenVipps = null;
+
+        private bool _adyenVippsSet = false;
+
+        public bool ShouldSerializeAdyenVipps() => _adyenVippsSet;
 
         /// <summary>
         /// Custom options to be passed to the `affirm-affirm` connector.
         /// </summary>
-        [JsonProperty("affirm-affirm")]
-        public AffirmOptions? AffirmAffirm { get; set; } = null;
+        [JsonProperty("affirm-affirm", NullValueHandling = NullValueHandling.Include)]
+        public AffirmOptions? AffirmAffirm
+        {
+            get => _affirmAffirm;
+            set
+            {
+                _affirmAffirm = value;
+                _affirmAffirmSet = true;
+            }
+        }
+
+        private AffirmOptions? _affirmAffirm = null;
+
+        private bool _affirmAffirmSet = false;
+
+        public bool ShouldSerializeAffirmAffirm() => _affirmAffirmSet;
 
         /// <summary>
         /// Custom options to be passed to the `braintree-card` connector.
         /// </summary>
-        [JsonProperty("braintree-card")]
-        public BraintreeOptions? BraintreeCard { get; set; } = null;
+        [JsonProperty("braintree-card", NullValueHandling = NullValueHandling.Include)]
+        public BraintreeOptions? BraintreeCard
+        {
+            get => _braintreeCard;
+            set
+            {
+                _braintreeCard = value;
+                _braintreeCardSet = true;
+            }
+        }
+
+        private BraintreeOptions? _braintreeCard = null;
+
+        private bool _braintreeCardSet = false;
+
+        public bool ShouldSerializeBraintreeCard() => _braintreeCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `chaseorbital-card` connector.
         /// </summary>
-        [JsonProperty("chaseorbital-card")]
-        public ChaseOptions? ChaseorbitalCard { get; set; } = null;
+        [JsonProperty("chaseorbital-card", NullValueHandling = NullValueHandling.Include)]
+        public ChaseOptions? ChaseorbitalCard
+        {
+            get => _chaseorbitalCard;
+            set
+            {
+                _chaseorbitalCard = value;
+                _chaseorbitalCardSet = true;
+            }
+        }
+
+        private ChaseOptions? _chaseorbitalCard = null;
+
+        private bool _chaseorbitalCardSet = false;
+
+        public bool ShouldSerializeChaseorbitalCard() => _chaseorbitalCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `cybersource-anti-fraud` connector.
         /// </summary>
-        [JsonProperty("cybersource-anti-fraud")]
-        public CybersourceAntiFraudOptions? CybersourceAntiFraud { get; set; } = null;
+        [JsonProperty("cybersource-anti-fraud", NullValueHandling = NullValueHandling.Include)]
+        public CybersourceAntiFraudOptions? CybersourceAntiFraud
+        {
+            get => _cybersourceAntiFraud;
+            set
+            {
+                _cybersourceAntiFraud = value;
+                _cybersourceAntiFraudSet = true;
+            }
+        }
+
+        private CybersourceAntiFraudOptions? _cybersourceAntiFraud = null;
+
+        private bool _cybersourceAntiFraudSet = false;
+
+        public bool ShouldSerializeCybersourceAntiFraud() => _cybersourceAntiFraudSet;
 
         /// <summary>
         /// Custom options to be passed to the `cybersource-card` connector.
         /// </summary>
-        [JsonProperty("cybersource-card")]
-        public CybersourceOptions? CybersourceCard { get; set; } = null;
+        [JsonProperty("cybersource-card", NullValueHandling = NullValueHandling.Include)]
+        public CybersourceOptions? CybersourceCard
+        {
+            get => _cybersourceCard;
+            set
+            {
+                _cybersourceCard = value;
+                _cybersourceCardSet = true;
+            }
+        }
+
+        private CybersourceOptions? _cybersourceCard = null;
+
+        private bool _cybersourceCardSet = false;
+
+        public bool ShouldSerializeCybersourceCard() => _cybersourceCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `cybersource-ideal` connector.
         /// </summary>
-        [JsonProperty("cybersource-ideal")]
-        public CybersourceOptions? CybersourceIdeal { get; set; } = null;
+        [JsonProperty("cybersource-ideal", NullValueHandling = NullValueHandling.Include)]
+        public CybersourceOptions? CybersourceIdeal
+        {
+            get => _cybersourceIdeal;
+            set
+            {
+                _cybersourceIdeal = value;
+                _cybersourceIdealSet = true;
+            }
+        }
+
+        private CybersourceOptions? _cybersourceIdeal = null;
+
+        private bool _cybersourceIdealSet = false;
+
+        public bool ShouldSerializeCybersourceIdeal() => _cybersourceIdealSet;
 
         /// <summary>
         /// Custom options to be passed to the `cybersource-kcp` connector.
         /// </summary>
-        [JsonProperty("cybersource-kcp")]
-        public CybersourceOptions? CybersourceKcp { get; set; } = null;
+        [JsonProperty("cybersource-kcp", NullValueHandling = NullValueHandling.Include)]
+        public CybersourceOptions? CybersourceKcp
+        {
+            get => _cybersourceKcp;
+            set
+            {
+                _cybersourceKcp = value;
+                _cybersourceKcpSet = true;
+            }
+        }
+
+        private CybersourceOptions? _cybersourceKcp = null;
+
+        private bool _cybersourceKcpSet = false;
+
+        public bool ShouldSerializeCybersourceKcp() => _cybersourceKcpSet;
 
         /// <summary>
         /// Custom options to be passed to the `dlocal-nequi` connector.
         /// </summary>
-        [JsonProperty("dlocal-nequi")]
-        public DlocalOptions? DlocalNequi { get; set; } = null;
+        [JsonProperty("dlocal-nequi", NullValueHandling = NullValueHandling.Include)]
+        public DlocalOptions? DlocalNequi
+        {
+            get => _dlocalNequi;
+            set
+            {
+                _dlocalNequi = value;
+                _dlocalNequiSet = true;
+            }
+        }
+
+        private DlocalOptions? _dlocalNequi = null;
+
+        private bool _dlocalNequiSet = false;
+
+        public bool ShouldSerializeDlocalNequi() => _dlocalNequiSet;
 
         /// <summary>
         /// Custom options to be passed to the `dlocal-upi` connector.
         /// </summary>
-        [JsonProperty("dlocal-upi")]
-        public DlocalUPIOptions? DlocalUpi { get; set; } = null;
+        [JsonProperty("dlocal-upi", NullValueHandling = NullValueHandling.Include)]
+        public DlocalUPIOptions? DlocalUpi
+        {
+            get => _dlocalUpi;
+            set
+            {
+                _dlocalUpi = value;
+                _dlocalUpiSet = true;
+            }
+        }
+
+        private DlocalUPIOptions? _dlocalUpi = null;
+
+        private bool _dlocalUpiSet = false;
+
+        public bool ShouldSerializeDlocalUpi() => _dlocalUpiSet;
 
         /// <summary>
         /// Custom options to be passed to the `dlocal-pix` connector.
         /// </summary>
-        [JsonProperty("dlocal-pix")]
-        public DlocalPIXOptions? DlocalPix { get; set; } = null;
+        [JsonProperty("dlocal-pix", NullValueHandling = NullValueHandling.Include)]
+        public DlocalPIXOptions? DlocalPix
+        {
+            get => _dlocalPix;
+            set
+            {
+                _dlocalPix = value;
+                _dlocalPixSet = true;
+            }
+        }
+
+        private DlocalPIXOptions? _dlocalPix = null;
+
+        private bool _dlocalPixSet = false;
+
+        public bool ShouldSerializeDlocalPix() => _dlocalPixSet;
 
         /// <summary>
         /// Custom options to be passed to the `dlocal-gcash` connector.
         /// </summary>
-        [JsonProperty("dlocal-gcash")]
-        public DlocalOptions? DlocalGcash { get; set; } = null;
+        [JsonProperty("dlocal-gcash", NullValueHandling = NullValueHandling.Include)]
+        public DlocalOptions? DlocalGcash
+        {
+            get => _dlocalGcash;
+            set
+            {
+                _dlocalGcash = value;
+                _dlocalGcashSet = true;
+            }
+        }
+
+        private DlocalOptions? _dlocalGcash = null;
+
+        private bool _dlocalGcashSet = false;
+
+        public bool ShouldSerializeDlocalGcash() => _dlocalGcashSet;
 
         /// <summary>
         /// Custom options to be passed to the `ecommpay-card` connector.
         /// </summary>
-        [JsonProperty("ecommpay-card")]
-        public EcommpayOptions? EcommpayCard { get; set; } = null;
+        [JsonProperty("ecommpay-card", NullValueHandling = NullValueHandling.Include)]
+        public EcommpayOptions? EcommpayCard
+        {
+            get => _ecommpayCard;
+            set
+            {
+                _ecommpayCard = value;
+                _ecommpayCardSet = true;
+            }
+        }
+
+        private EcommpayOptions? _ecommpayCard = null;
+
+        private bool _ecommpayCardSet = false;
+
+        public bool ShouldSerializeEcommpayCard() => _ecommpayCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `fiserv-card` connector.
         /// </summary>
-        [JsonProperty("fiserv-card")]
-        public FiservOptions? FiservCard { get; set; } = null;
+        [JsonProperty("fiserv-card", NullValueHandling = NullValueHandling.Include)]
+        public FiservOptions? FiservCard
+        {
+            get => _fiservCard;
+            set
+            {
+                _fiservCard = value;
+                _fiservCardSet = true;
+            }
+        }
+
+        private FiservOptions? _fiservCard = null;
+
+        private bool _fiservCardSet = false;
+
+        public bool ShouldSerializeFiservCard() => _fiservCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `forter-anti-fraud` connector.
         /// </summary>
-        [JsonProperty("forter-anti-fraud")]
-        public ForterAntiFraudOptions? ForterAntiFraud { get; set; } = null;
+        [JsonProperty("forter-anti-fraud", NullValueHandling = NullValueHandling.Include)]
+        public ForterAntiFraudOptions? ForterAntiFraud
+        {
+            get => _forterAntiFraud;
+            set
+            {
+                _forterAntiFraud = value;
+                _forterAntiFraudSet = true;
+            }
+        }
+
+        private ForterAntiFraudOptions? _forterAntiFraud = null;
+
+        private bool _forterAntiFraudSet = false;
+
+        public bool ShouldSerializeForterAntiFraud() => _forterAntiFraudSet;
 
         /// <summary>
         /// Custom options to be passed to the `gem-gem` connector.
         /// </summary>
-        [JsonProperty("gem-gem")]
-        public LatitudeOptions? GemGem { get; set; } = null;
+        [JsonProperty("gem-gem", NullValueHandling = NullValueHandling.Include)]
+        public LatitudeOptions? GemGem
+        {
+            get => _gemGem;
+            set
+            {
+                _gemGem = value;
+                _gemGemSet = true;
+            }
+        }
+
+        private LatitudeOptions? _gemGem = null;
+
+        private bool _gemGemSet = false;
+
+        public bool ShouldSerializeGemGem() => _gemGemSet;
 
         /// <summary>
         /// Custom options to be passed to the `gem-gemds` connector.
         /// </summary>
-        [JsonProperty("gem-gemds")]
-        public LatitudeOptions? GemGemds { get; set; } = null;
+        [JsonProperty("gem-gemds", NullValueHandling = NullValueHandling.Include)]
+        public LatitudeOptions? GemGemds
+        {
+            get => _gemGemds;
+            set
+            {
+                _gemGemds = value;
+                _gemGemdsSet = true;
+            }
+        }
+
+        private LatitudeOptions? _gemGemds = null;
+
+        private bool _gemGemdsSet = false;
+
+        public bool ShouldSerializeGemGemds() => _gemGemdsSet;
 
         /// <summary>
         /// Custom options to be passed to the `givingblock-givingblock` connector.
         /// </summary>
-        [JsonProperty("givingblock-givingblock")]
-        public GivingBlockOptions? GivingblockGivingblock { get; set; } = null;
+        [JsonProperty("givingblock-givingblock", NullValueHandling = NullValueHandling.Include)]
+        public GivingBlockOptions? GivingblockGivingblock
+        {
+            get => _givingblockGivingblock;
+            set
+            {
+                _givingblockGivingblock = value;
+                _givingblockGivingblockSet = true;
+            }
+        }
+
+        private GivingBlockOptions? _givingblockGivingblock = null;
+
+        private bool _givingblockGivingblockSet = false;
+
+        public bool ShouldSerializeGivingblockGivingblock() => _givingblockGivingblockSet;
 
         /// <summary>
         /// Custom options to be passed to the `gocardless-gocardless` connector.
         /// </summary>
-        [JsonProperty("gocardless-gocardless")]
-        public GoCardlessOptions? GocardlessGocardless { get; set; } = null;
+        [JsonProperty("gocardless-gocardless", NullValueHandling = NullValueHandling.Include)]
+        public GoCardlessOptions? GocardlessGocardless
+        {
+            get => _gocardlessGocardless;
+            set
+            {
+                _gocardlessGocardless = value;
+                _gocardlessGocardlessSet = true;
+            }
+        }
+
+        private GoCardlessOptions? _gocardlessGocardless = null;
+
+        private bool _gocardlessGocardlessSet = false;
+
+        public bool ShouldSerializeGocardlessGocardless() => _gocardlessGocardlessSet;
 
         /// <summary>
         /// Custom options to be passed to the `latitude-latitude` connector.
         /// </summary>
-        [JsonProperty("latitude-latitude")]
-        public LatitudeOptions? LatitudeLatitude { get; set; } = null;
+        [JsonProperty("latitude-latitude", NullValueHandling = NullValueHandling.Include)]
+        public LatitudeOptions? LatitudeLatitude
+        {
+            get => _latitudeLatitude;
+            set
+            {
+                _latitudeLatitude = value;
+                _latitudeLatitudeSet = true;
+            }
+        }
+
+        private LatitudeOptions? _latitudeLatitude = null;
+
+        private bool _latitudeLatitudeSet = false;
+
+        public bool ShouldSerializeLatitudeLatitude() => _latitudeLatitudeSet;
 
         /// <summary>
         /// Custom options to be passed to the `latitude-latitudeds` connector.
         /// </summary>
-        [JsonProperty("latitude-latitudeds")]
-        public LatitudeOptions? LatitudeLatitudeds { get; set; } = null;
+        [JsonProperty("latitude-latitudeds", NullValueHandling = NullValueHandling.Include)]
+        public LatitudeOptions? LatitudeLatitudeds
+        {
+            get => _latitudeLatitudeds;
+            set
+            {
+                _latitudeLatitudeds = value;
+                _latitudeLatitudedsSet = true;
+            }
+        }
+
+        private LatitudeOptions? _latitudeLatitudeds = null;
+
+        private bool _latitudeLatitudedsSet = false;
+
+        public bool ShouldSerializeLatitudeLatitudeds() => _latitudeLatitudedsSet;
 
         /// <summary>
         /// Custom options to be passed to the `mattilda-tapi` connector.
         /// </summary>
-        [JsonProperty("mattilda-tapi")]
-        public MattildaTapiOptions? MattildaTapi { get; set; } = null;
+        [JsonProperty("mattilda-tapi", NullValueHandling = NullValueHandling.Include)]
+        public MattildaTapiOptions? MattildaTapi
+        {
+            get => _mattildaTapi;
+            set
+            {
+                _mattildaTapi = value;
+                _mattildaTapiSet = true;
+            }
+        }
+
+        private MattildaTapiOptions? _mattildaTapi = null;
+
+        private bool _mattildaTapiSet = false;
+
+        public bool ShouldSerializeMattildaTapi() => _mattildaTapiSet;
 
         /// <summary>
         /// Custom options to be passed to the `mattilda-tapifintechs` connector.
         /// </summary>
-        [JsonProperty("mattilda-tapifintechs")]
-        public MattildaTapiOptions? MattildaTapifintechs { get; set; } = null;
+        [JsonProperty("mattilda-tapifintechs", NullValueHandling = NullValueHandling.Include)]
+        public MattildaTapiOptions? MattildaTapifintechs
+        {
+            get => _mattildaTapifintechs;
+            set
+            {
+                _mattildaTapifintechs = value;
+                _mattildaTapifintechsSet = true;
+            }
+        }
+
+        private MattildaTapiOptions? _mattildaTapifintechs = null;
+
+        private bool _mattildaTapifintechsSet = false;
+
+        public bool ShouldSerializeMattildaTapifintechs() => _mattildaTapifintechsSet;
 
         /// <summary>
         /// Custom options to be passed to the `monato-spei` connector.
         /// </summary>
-        [JsonProperty("monato-spei")]
-        public MonatoSpeiOptions? MonatoSpei { get; set; } = null;
+        [JsonProperty("monato-spei", NullValueHandling = NullValueHandling.Include)]
+        public MonatoSpeiOptions? MonatoSpei
+        {
+            get => _monatoSpei;
+            set
+            {
+                _monatoSpei = value;
+                _monatoSpeiSet = true;
+            }
+        }
+
+        private MonatoSpeiOptions? _monatoSpei = null;
+
+        private bool _monatoSpeiSet = false;
+
+        public bool ShouldSerializeMonatoSpei() => _monatoSpeiSet;
 
         /// <summary>
         /// Custom options to be passed to the `mock-card` connector.
         /// </summary>
-        [JsonProperty("mock-card")]
-        public MockCardOptions? MockCard { get; set; } = null;
+        [JsonProperty("mock-card", NullValueHandling = NullValueHandling.Include)]
+        public MockCardOptions? MockCard
+        {
+            get => _mockCard;
+            set
+            {
+                _mockCard = value;
+                _mockCardSet = true;
+            }
+        }
+
+        private MockCardOptions? _mockCard = null;
+
+        private bool _mockCardSet = false;
+
+        public bool ShouldSerializeMockCard() => _mockCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `mockds-card` connector.
         /// </summary>
-        [JsonProperty("mockds-card")]
-        public MockCardOptions? MockdsCard { get; set; } = null;
+        [JsonProperty("mockds-card", NullValueHandling = NullValueHandling.Include)]
+        public MockCardOptions? MockdsCard
+        {
+            get => _mockdsCard;
+            set
+            {
+                _mockdsCard = value;
+                _mockdsCardSet = true;
+            }
+        }
+
+        private MockCardOptions? _mockdsCard = null;
+
+        private bool _mockdsCardSet = false;
+
+        public bool ShouldSerializeMockdsCard() => _mockdsCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `nuvei-card` connector.
         /// </summary>
-        [JsonProperty("nuvei-card")]
-        public NuveiOptions? NuveiCard { get; set; } = null;
+        [JsonProperty("nuvei-card", NullValueHandling = NullValueHandling.Include)]
+        public NuveiOptions? NuveiCard
+        {
+            get => _nuveiCard;
+            set
+            {
+                _nuveiCard = value;
+                _nuveiCardSet = true;
+            }
+        }
+
+        private NuveiOptions? _nuveiCard = null;
+
+        private bool _nuveiCardSet = false;
+
+        public bool ShouldSerializeNuveiCard() => _nuveiCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `nuvei-ideal` connector.
         /// </summary>
-        [JsonProperty("nuvei-ideal")]
-        public NuveiIDealOptions? NuveiIdeal { get; set; } = null;
+        [JsonProperty("nuvei-ideal", NullValueHandling = NullValueHandling.Include)]
+        public NuveiIDealOptions? NuveiIdeal
+        {
+            get => _nuveiIdeal;
+            set
+            {
+                _nuveiIdeal = value;
+                _nuveiIdealSet = true;
+            }
+        }
+
+        private NuveiIDealOptions? _nuveiIdeal = null;
+
+        private bool _nuveiIdealSet = false;
+
+        public bool ShouldSerializeNuveiIdeal() => _nuveiIdealSet;
 
         /// <summary>
         /// Custom options to be passed to the `nuvei-klarna` connector.
         /// </summary>
-        [JsonProperty("nuvei-klarna")]
-        public NuveiKlarnaOptions? NuveiKlarna { get; set; } = null;
+        [JsonProperty("nuvei-klarna", NullValueHandling = NullValueHandling.Include)]
+        public NuveiKlarnaOptions? NuveiKlarna
+        {
+            get => _nuveiKlarna;
+            set
+            {
+                _nuveiKlarna = value;
+                _nuveiKlarnaSet = true;
+            }
+        }
+
+        private NuveiKlarnaOptions? _nuveiKlarna = null;
+
+        private bool _nuveiKlarnaSet = false;
+
+        public bool ShouldSerializeNuveiKlarna() => _nuveiKlarnaSet;
 
         /// <summary>
         /// Custom options to be passed to the `nuvei-pse` connector.
         /// </summary>
-        [JsonProperty("nuvei-pse")]
-        public NuveiPSEOptions? NuveiPse { get; set; } = null;
+        [JsonProperty("nuvei-pse", NullValueHandling = NullValueHandling.Include)]
+        public NuveiPSEOptions? NuveiPse
+        {
+            get => _nuveiPse;
+            set
+            {
+                _nuveiPse = value;
+                _nuveiPseSet = true;
+            }
+        }
+
+        private NuveiPSEOptions? _nuveiPse = null;
+
+        private bool _nuveiPseSet = false;
+
+        public bool ShouldSerializeNuveiPse() => _nuveiPseSet;
 
         /// <summary>
         /// Custom options to be passed to the `oxxo-oxxo` connector.
         /// </summary>
-        [JsonProperty("oxxo-oxxo")]
-        public OxxoOptions? OxxoOxxo { get; set; } = null;
+        [JsonProperty("oxxo-oxxo", NullValueHandling = NullValueHandling.Include)]
+        public OxxoOptions? OxxoOxxo
+        {
+            get => _oxxoOxxo;
+            set
+            {
+                _oxxoOxxo = value;
+                _oxxoOxxoSet = true;
+            }
+        }
+
+        private OxxoOptions? _oxxoOxxo = null;
+
+        private bool _oxxoOxxoSet = false;
+
+        public bool ShouldSerializeOxxoOxxo() => _oxxoOxxoSet;
 
         /// <summary>
         /// Custom options to be passed to the `paypal-paypal` connector.
         /// </summary>
-        [JsonProperty("paypal-paypal")]
-        public PaypalOptions? PaypalPaypal { get; set; } = null;
+        [JsonProperty("paypal-paypal", NullValueHandling = NullValueHandling.Include)]
+        public PaypalOptions? PaypalPaypal
+        {
+            get => _paypalPaypal;
+            set
+            {
+                _paypalPaypal = value;
+                _paypalPaypalSet = true;
+            }
+        }
+
+        private PaypalOptions? _paypalPaypal = null;
+
+        private bool _paypalPaypalSet = false;
+
+        public bool ShouldSerializePaypalPaypal() => _paypalPaypalSet;
 
         /// <summary>
         /// Custom options to be passed to the `paypal-paypalpaylater` connector.
         /// </summary>
-        [JsonProperty("paypal-paypalpaylater")]
-        public PaypalOptions? PaypalPaypalpaylater { get; set; } = null;
+        [JsonProperty("paypal-paypalpaylater", NullValueHandling = NullValueHandling.Include)]
+        public PaypalOptions? PaypalPaypalpaylater
+        {
+            get => _paypalPaypalpaylater;
+            set
+            {
+                _paypalPaypalpaylater = value;
+                _paypalPaypalpaylaterSet = true;
+            }
+        }
+
+        private PaypalOptions? _paypalPaypalpaylater = null;
+
+        private bool _paypalPaypalpaylaterSet = false;
+
+        public bool ShouldSerializePaypalPaypalpaylater() => _paypalPaypalpaylaterSet;
 
         /// <summary>
         /// Custom options to be passed to the `powertranz-card` connector.
         /// </summary>
-        [JsonProperty("powertranz-card")]
-        public PowertranzOptions? PowertranzCard { get; set; } = null;
+        [JsonProperty("powertranz-card", NullValueHandling = NullValueHandling.Include)]
+        public PowertranzOptions? PowertranzCard
+        {
+            get => _powertranzCard;
+            set
+            {
+                _powertranzCard = value;
+                _powertranzCardSet = true;
+            }
+        }
+
+        private PowertranzOptions? _powertranzCard = null;
+
+        private bool _powertranzCardSet = false;
+
+        public bool ShouldSerializePowertranzCard() => _powertranzCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `riskified-anti-fraud` connector.
         /// </summary>
-        [JsonProperty("riskified-anti-fraud")]
-        public RiskifiedAntiFraudOptions? RiskifiedAntiFraud { get; set; } = null;
+        [JsonProperty("riskified-anti-fraud", NullValueHandling = NullValueHandling.Include)]
+        public RiskifiedAntiFraudOptions? RiskifiedAntiFraud
+        {
+            get => _riskifiedAntiFraud;
+            set
+            {
+                _riskifiedAntiFraud = value;
+                _riskifiedAntiFraudSet = true;
+            }
+        }
+
+        private RiskifiedAntiFraudOptions? _riskifiedAntiFraud = null;
+
+        private bool _riskifiedAntiFraudSet = false;
+
+        public bool ShouldSerializeRiskifiedAntiFraud() => _riskifiedAntiFraudSet;
 
         /// <summary>
         /// Custom options to be passed to the `stripe-affirm` connector.
         /// </summary>
-        [JsonProperty("stripe-affirm")]
-        public StripeOptions? StripeAffirm { get; set; } = null;
+        [JsonProperty("stripe-affirm", NullValueHandling = NullValueHandling.Include)]
+        public StripeOptions? StripeAffirm
+        {
+            get => _stripeAffirm;
+            set
+            {
+                _stripeAffirm = value;
+                _stripeAffirmSet = true;
+            }
+        }
+
+        private StripeOptions? _stripeAffirm = null;
+
+        private bool _stripeAffirmSet = false;
+
+        public bool ShouldSerializeStripeAffirm() => _stripeAffirmSet;
 
         /// <summary>
         /// Custom options to be passed to the `stripe-card` connector.
         /// </summary>
-        [JsonProperty("stripe-card")]
-        public StripeCardOptions? StripeCard { get; set; } = null;
+        [JsonProperty("stripe-card", NullValueHandling = NullValueHandling.Include)]
+        public StripeCardOptions? StripeCard
+        {
+            get => _stripeCard;
+            set
+            {
+                _stripeCard = value;
+                _stripeCardSet = true;
+            }
+        }
+
+        private StripeCardOptions? _stripeCard = null;
+
+        private bool _stripeCardSet = false;
+
+        public bool ShouldSerializeStripeCard() => _stripeCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `stripe-klarna` connector.
         /// </summary>
-        [JsonProperty("stripe-klarna")]
-        public StripeOptions? StripeKlarna { get; set; } = null;
+        [JsonProperty("stripe-klarna", NullValueHandling = NullValueHandling.Include)]
+        public StripeOptions? StripeKlarna
+        {
+            get => _stripeKlarna;
+            set
+            {
+                _stripeKlarna = value;
+                _stripeKlarnaSet = true;
+            }
+        }
+
+        private StripeOptions? _stripeKlarna = null;
+
+        private bool _stripeKlarnaSet = false;
+
+        public bool ShouldSerializeStripeKlarna() => _stripeKlarnaSet;
 
         /// <summary>
         /// Custom options to be passed to the `travelhub-card` connector.
         /// </summary>
-        [JsonProperty("travelhub-card")]
-        public TravelhubOptions? TravelhubCard { get; set; } = null;
+        [JsonProperty("travelhub-card", NullValueHandling = NullValueHandling.Include)]
+        public TravelhubOptions? TravelhubCard
+        {
+            get => _travelhubCard;
+            set
+            {
+                _travelhubCard = value;
+                _travelhubCardSet = true;
+            }
+        }
+
+        private TravelhubOptions? _travelhubCard = null;
+
+        private bool _travelhubCardSet = false;
+
+        public bool ShouldSerializeTravelhubCard() => _travelhubCardSet;
 
         /// <summary>
         /// Custom options to be passed to the `trustly-trustly` connector.
         /// </summary>
-        [JsonProperty("trustly-trustly")]
-        public TrustlyOptions? TrustlyTrustly { get; set; } = null;
+        [JsonProperty("trustly-trustly", NullValueHandling = NullValueHandling.Include)]
+        public TrustlyOptions? TrustlyTrustly
+        {
+            get => _trustlyTrustly;
+            set
+            {
+                _trustlyTrustly = value;
+                _trustlyTrustlySet = true;
+            }
+        }
+
+        private TrustlyOptions? _trustlyTrustly = null;
+
+        private bool _trustlyTrustlySet = false;
+
+        public bool ShouldSerializeTrustlyTrustly() => _trustlyTrustlySet;
 
         /// <summary>
         /// Custom options to be passed to the `wpay-everydaypay` connector.
         /// </summary>
-        [JsonProperty("wpay-everydaypay")]
-        public WpayEverdaypayOptions? WpayEverydaypay { get; set; } = null;
+        [JsonProperty("wpay-everydaypay", NullValueHandling = NullValueHandling.Include)]
+        public WpayEverdaypayOptions? WpayEverydaypay
+        {
+            get => _wpayEverydaypay;
+            set
+            {
+                _wpayEverydaypay = value;
+                _wpayEverydaypaySet = true;
+            }
+        }
+
+        private WpayEverdaypayOptions? _wpayEverydaypay = null;
+
+        private bool _wpayEverydaypaySet = false;
+
+        public bool ShouldSerializeWpayEverydaypay() => _wpayEverydaypaySet;
 
         /// <summary>
         /// Custom options to be passed to the `wpay-payto` connector.
         /// </summary>
-        [JsonProperty("wpay-payto")]
-        public WpayPaytoOptions? WpayPayto { get; set; } = null;
+        [JsonProperty("wpay-payto", NullValueHandling = NullValueHandling.Include)]
+        public WpayPaytoOptions? WpayPayto
+        {
+            get => _wpayPayto;
+            set
+            {
+                _wpayPayto = value;
+                _wpayPaytoSet = true;
+            }
+        }
+
+        private WpayPaytoOptions? _wpayPayto = null;
+
+        private bool _wpayPaytoSet = false;
+
+        public bool ShouldSerializeWpayPayto() => _wpayPaytoSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TravelHubCustomData.cs
+++ b/src/Gr4vy/Models/Components/TravelHubCustomData.cs
@@ -17,19 +17,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The key of the custom data field.
         /// </summary>
-        [JsonProperty("name")]
-        public string Name { get; set; } = default!;
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Include)]
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                _name = value;
+                _nameSet = true;
+            }
+        }
+
+        private string _name = default!;
+
+        private bool _nameSet = true;
+
+        public bool ShouldSerializeName() => _nameSet;
 
         /// <summary>
         /// The value of the custom data field.
         /// </summary>
-        [JsonProperty("value")]
-        public string Value { get; set; } = default!;
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
+
+        private string _value = default!;
+
+        private bool _valueSet = true;
+
+        public bool ShouldSerializeValue() => _valueSet;
 
         /// <summary>
         /// The type of the custom data field.
         /// </summary>
-        [JsonProperty("type")]
-        public string? Type { get; set; } = null;
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Include)]
+        public string? Type
+        {
+            get => _type;
+            set
+            {
+                _type = value;
+                _typeSet = true;
+            }
+        }
+
+        private string? _type = null;
+
+        private bool _typeSet = false;
+
+        public bool ShouldSerializeType() => _typeSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TravelhubOptions.cs
+++ b/src/Gr4vy/Models/Components/TravelhubOptions.cs
@@ -19,13 +19,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// A list of `customData` to pass to the TravelHub API.
         /// </summary>
-        [JsonProperty("customData")]
-        public List<TravelHubCustomData>? CustomData { get; set; } = null;
+        [JsonProperty("customData", NullValueHandling = NullValueHandling.Include)]
+        public List<TravelHubCustomData>? CustomData
+        {
+            get => _customData;
+            set
+            {
+                _customData = value;
+                _customDataSet = true;
+            }
+        }
+
+        private List<TravelHubCustomData>? _customData = null;
+
+        private bool _customDataSet = false;
+
+        public bool ShouldSerializeCustomData() => _customDataSet;
 
         /// <summary>
         /// Customer company name to pass to the TravelHub API.
         /// </summary>
-        [JsonProperty("companyName")]
-        public string? CompanyName { get; set; } = null;
+        [JsonProperty("companyName", NullValueHandling = NullValueHandling.Include)]
+        public string? CompanyName
+        {
+            get => _companyName;
+            set
+            {
+                _companyName = value;
+                _companyNameSet = true;
+            }
+        }
+
+        private string? _companyName = null;
+
+        private bool _companyNameSet = false;
+
+        public bool ShouldSerializeCompanyName() => _companyNameSet;
     }
 }

--- a/src/Gr4vy/Models/Components/TrustlyOptions.cs
+++ b/src/Gr4vy/Models/Components/TrustlyOptions.cs
@@ -17,7 +17,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Indicates to Gr4vy whether or not the stored Trustly agreement needs refreshing.
         /// </summary>
-        [JsonProperty("refreshSplitToken")]
-        public bool? RefreshSplitToken { get; set; } = null;
+        [JsonProperty("refreshSplitToken", NullValueHandling = NullValueHandling.Include)]
+        public bool? RefreshSplitToken
+        {
+            get => _refreshSplitToken;
+            set
+            {
+                _refreshSplitToken = value;
+                _refreshSplitTokenSet = true;
+            }
+        }
+
+        private bool? _refreshSplitToken = null;
+
+        private bool _refreshSplitTokenSet = false;
+
+        public bool ShouldSerializeRefreshSplitToken() => _refreshSplitTokenSet;
     }
 }

--- a/src/Gr4vy/Models/Components/VoidableField.cs
+++ b/src/Gr4vy/Models/Components/VoidableField.cs
@@ -14,10 +14,38 @@ namespace Gr4vy.Models.Components
 
     public class VoidableField
     {
-        [JsonProperty("key")]
-        public string Key { get; set; } = default!;
+        [JsonProperty("key", NullValueHandling = NullValueHandling.Include)]
+        public string Key
+        {
+            get => _key;
+            set
+            {
+                _key = value;
+                _keySet = true;
+            }
+        }
 
-        [JsonProperty("value")]
-        public string Value { get; set; } = default!;
+        private string _key = default!;
+
+        private bool _keySet = true;
+
+        public bool ShouldSerializeKey() => _keySet;
+
+        [JsonProperty("value", NullValueHandling = NullValueHandling.Include)]
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                _value = value;
+                _valueSet = true;
+            }
+        }
+
+        private string _value = default!;
+
+        private bool _valueSet = true;
+
+        public bool ShouldSerializeValue() => _valueSet;
     }
 }

--- a/src/Gr4vy/Models/Components/WpayEverdaypayOptions.cs
+++ b/src/Gr4vy/Models/Components/WpayEverdaypayOptions.cs
@@ -18,31 +18,101 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// A dictionary of merchant defined data, to be passed to Wpay for anti-fraud control.
         /// </summary>
-        [JsonProperty("merchant_defined_data")]
-        public Dictionary<string, string>? MerchantDefinedData { get; set; } = null;
+        [JsonProperty("merchant_defined_data", NullValueHandling = NullValueHandling.Include)]
+        public Dictionary<string, string>? MerchantDefinedData
+        {
+            get => _merchantDefinedData;
+            set
+            {
+                _merchantDefinedData = value;
+                _merchantDefinedDataSet = true;
+            }
+        }
+
+        private Dictionary<string, string>? _merchantDefinedData = null;
+
+        private bool _merchantDefinedDataSet = false;
+
+        public bool ShouldSerializeMerchantDefinedData() => _merchantDefinedDataSet;
 
         /// <summary>
         /// The customer ID for the Everyday Rewards account.
         /// </summary>
-        [JsonProperty("customerId")]
-        public string? CustomerId { get; set; } = null;
+        [JsonProperty("customerId", NullValueHandling = NullValueHandling.Include)]
+        public string? CustomerId
+        {
+            get => _customerId;
+            set
+            {
+                _customerId = value;
+                _customerIdSet = true;
+            }
+        }
+
+        private string? _customerId = null;
+
+        private bool _customerIdSet = false;
+
+        public bool ShouldSerializeCustomerId() => _customerIdSet;
 
         /// <summary>
         /// The access token for the Everyday Rewards account.
         /// </summary>
-        [JsonProperty("rewardsAccessToken")]
-        public string? RewardsAccessToken { get; set; } = null;
+        [JsonProperty("rewardsAccessToken", NullValueHandling = NullValueHandling.Include)]
+        public string? RewardsAccessToken
+        {
+            get => _rewardsAccessToken;
+            set
+            {
+                _rewardsAccessToken = value;
+                _rewardsAccessTokenSet = true;
+            }
+        }
+
+        private string? _rewardsAccessToken = null;
+
+        private bool _rewardsAccessTokenSet = false;
+
+        public bool ShouldSerializeRewardsAccessToken() => _rewardsAccessTokenSet;
 
         /// <summary>
         /// The ID of the device on which the payment is occuring.
         /// </summary>
-        [JsonProperty("deviceId")]
-        public string? DeviceId { get; set; } = null;
+        [JsonProperty("deviceId", NullValueHandling = NullValueHandling.Include)]
+        public string? DeviceId
+        {
+            get => _deviceId;
+            set
+            {
+                _deviceId = value;
+                _deviceIdSet = true;
+            }
+        }
+
+        private string? _deviceId = null;
+
+        private bool _deviceIdSet = false;
+
+        public bool ShouldSerializeDeviceId() => _deviceIdSet;
 
         /// <summary>
         /// Whether the transaction should redirect post-payment.
         /// </summary>
-        [JsonProperty("postPaymentRedirect")]
-        public bool? PostPaymentRedirect { get; set; } = null;
+        [JsonProperty("postPaymentRedirect", NullValueHandling = NullValueHandling.Include)]
+        public bool? PostPaymentRedirect
+        {
+            get => _postPaymentRedirect;
+            set
+            {
+                _postPaymentRedirect = value;
+                _postPaymentRedirectSet = true;
+            }
+        }
+
+        private bool? _postPaymentRedirect = null;
+
+        private bool _postPaymentRedirectSet = false;
+
+        public bool ShouldSerializePostPaymentRedirect() => _postPaymentRedirectSet;
     }
 }

--- a/src/Gr4vy/Models/Components/WpayPaytoOptions.cs
+++ b/src/Gr4vy/Models/Components/WpayPaytoOptions.cs
@@ -18,19 +18,61 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Options to pass to the `instrument` resource in the Wpay PayTo API.
         /// </summary>
-        [JsonProperty("instrument")]
-        public WpayPaytoResourceOptions? Instrument { get; set; } = null;
+        [JsonProperty("instrument", NullValueHandling = NullValueHandling.Include)]
+        public WpayPaytoResourceOptions? Instrument
+        {
+            get => _instrument;
+            set
+            {
+                _instrument = value;
+                _instrumentSet = true;
+            }
+        }
+
+        private WpayPaytoResourceOptions? _instrument = null;
+
+        private bool _instrumentSet = false;
+
+        public bool ShouldSerializeInstrument() => _instrumentSet;
 
         /// <summary>
         /// Options to pass to the `payment` resource in the Wpay PayTo API.
         /// </summary>
-        [JsonProperty("payment")]
-        public WpayPaytoResourceOptions? Payment { get; set; } = null;
+        [JsonProperty("payment", NullValueHandling = NullValueHandling.Include)]
+        public WpayPaytoResourceOptions? Payment
+        {
+            get => _payment;
+            set
+            {
+                _payment = value;
+                _paymentSet = true;
+            }
+        }
+
+        private WpayPaytoResourceOptions? _payment = null;
+
+        private bool _paymentSet = false;
+
+        public bool ShouldSerializePayment() => _paymentSet;
 
         /// <summary>
         /// Options to pass to the `refund` resource in the Wpay PayTo API.
         /// </summary>
-        [JsonProperty("refund")]
-        public WpayPaytoResourceOptions? Refund { get; set; } = null;
+        [JsonProperty("refund", NullValueHandling = NullValueHandling.Include)]
+        public WpayPaytoResourceOptions? Refund
+        {
+            get => _refund;
+            set
+            {
+                _refund = value;
+                _refundSet = true;
+            }
+        }
+
+        private WpayPaytoResourceOptions? _refund = null;
+
+        private bool _refundSet = false;
+
+        public bool ShouldSerializeRefund() => _refundSet;
     }
 }

--- a/src/Gr4vy/Models/Components/WpayPaytoResourceOptions.cs
+++ b/src/Gr4vy/Models/Components/WpayPaytoResourceOptions.cs
@@ -18,7 +18,21 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// Simulate responses for this resource.
         /// </summary>
-        [JsonProperty("simulation")]
-        public WpayPaytoSimulationOptions? Simulation { get; set; } = null;
+        [JsonProperty("simulation", NullValueHandling = NullValueHandling.Include)]
+        public WpayPaytoSimulationOptions? Simulation
+        {
+            get => _simulation;
+            set
+            {
+                _simulation = value;
+                _simulationSet = true;
+            }
+        }
+
+        private WpayPaytoSimulationOptions? _simulation = null;
+
+        private bool _simulationSet = false;
+
+        public bool ShouldSerializeSimulation() => _simulationSet;
     }
 }

--- a/src/Gr4vy/Models/Components/WpayPaytoSimulationOptions.cs
+++ b/src/Gr4vy/Models/Components/WpayPaytoSimulationOptions.cs
@@ -17,13 +17,41 @@ namespace Gr4vy.Models.Components
         /// <summary>
         /// The simulation being requested. Please refer to the developer guide for a list of all available simulations.
         /// </summary>
-        [JsonProperty("simulate")]
-        public string? Simulate { get; set; } = null;
+        [JsonProperty("simulate", NullValueHandling = NullValueHandling.Include)]
+        public string? Simulate
+        {
+            get => _simulate;
+            set
+            {
+                _simulate = value;
+                _simulateSet = true;
+            }
+        }
+
+        private string? _simulate = null;
+
+        private bool _simulateSet = false;
+
+        public bool ShouldSerializeSimulate() => _simulateSet;
 
         /// <summary>
         /// The delay in seconds before the requested simulation is executed.
         /// </summary>
-        [JsonProperty("delay")]
-        public long? Delay { get; set; } = null;
+        [JsonProperty("delay", NullValueHandling = NullValueHandling.Include)]
+        public long? Delay
+        {
+            get => _delay;
+            set
+            {
+                _delay = value;
+                _delaySet = true;
+            }
+        }
+
+        private long? _delay = null;
+
+        private bool _delaySet = false;
+
+        public bool ShouldSerializeDelay() => _delaySet;
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #196. Wpay reported that the tri-state nullable fix only cleared top-level `*Update` fields. Nested-object nulls were still dropped on the wire:

```csharp
BuyerUpdate.DisplayName = null;                              // cleared OK
BuyerUpdate.BillingDetails.Address.HouseNumberOrName = null; // NOT cleared
BuyerUpdate.BillingDetails.Address.Line2 = null;             // NOT cleared
BuyerUpdate.BillingDetails.Address.State = null;             // NOT cleared
BuyerUpdate.BillingDetails.Address.Organization = null;      // NOT cleared
```

## Root cause

`BuyerUpdate.BillingDetails` is typed as the shared `BillingDetails` class (re-used by create/response flows), which still emitted plain auto-properties. Combined with the global `NullValueHandling.Ignore`, any `null` on a nested field was dropped before serialization. The patch in #196 only rewrote files matching `*Update.cs`.

## Changes

- **`.speakeasy/scripts/patch_update_models.py`** — extended to BFS over property type references from each `*Update.cs` root and apply the same backing-field + `ShouldSerialize{X}()` rewrite to every transitively reachable component file. Reachability (rather than blanket-patching every component) keeps the blast radius minimal: response-only types stay untouched. The existing `ShouldSerialize` guard preserves idempotency.
- **78 nested component files** regenerated with the tri-state pattern (`Address`, `BillingDetails`, `TaxId`, `DigitalWalletAddress`, all `*Options` classes embedded in `PaymentServiceUpdate`, etc.).
- **`UpdateModelSerializationTest.cs`** — two new tests: explicit nulls on `BillingDetails.Address` produce JSON nulls; untouched nested fields still serialize as `{}`.
- **`BuyersUpdateIntegrationTest.cs`** — end-to-end test mirroring the Wpay repro against the e2e sandbox: create a buyer with a full billing address, clear the same nested fields, fetch back, assert they're null while untouched fields are preserved.

## Backwards compatibility

Nested types (`BillingDetails`, `Address`, `TaxId`, etc.) are also referenced by `*Create.cs` request models. The patch is backwards-compatible there: a property never assigned still serializes as omitted (`ShouldSerialize` returns `false`), so existing create-flow callers see no change. Only newly-introduced `= null` assignments produce explicit JSON nulls — which is the desired behavior.

Re-running the script reports 0 patched / 88 already-tri-state, confirming idempotency. The patch retires file-by-file once Speakeasy ships native `ShouldSerialize` emission.

## Test plan

- [ ] CI green (`dotnet build`, unit tests). I couldn't run `dotnet` locally on this machine.
- [ ] New unit tests `BuyerUpdate_NestedAddressField_*` pass against the patched serializer.
- [ ] New integration test `NestedAddressField_ExplicitNull_ClearsOnServer` passes against the e2e sandbox.
- [ ] Existing tests in `UpdateModelSerializationTest` still pass (no regression on top-level behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)