### PR TITLE
fix(spec): flatten report spec union so it can't serialize to null

### DIFF
--- a/.speakeasy/overlays/fix-report-spec-union.yaml
+++ b/.speakeasy/overlays/fix-report-spec-union.yaml
@@ -1,0 +1,38 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: Flatten the report spec union so it cannot serialize to null
+  version: 0.0.1
+# `ReportCreate.spec` is a discriminated `oneOf` of four report-spec variants
+# (transactions / transaction_retries / detailed_settlement / accounts_receivables),
+# each just `{ model: <const>, params: <free-form object> }`. Speakeasy renders that
+# as a C# union whose JSON writer emits a body only when one of the variant members
+# is set — so a Spec built without a body serialises the *required* `spec` field as
+# `null`, which the API's report validator cannot handle (Sentry CORE-API-3AE:
+# AttributeError on `values.get("spec", {}).get("model")`).
+#
+# The variants are structurally identical (params is a free-form object in every
+# case), so the union adds no type safety on the wire. Collapse it into a single
+# required object: `spec` then generates a plain model with required `model` +
+# `params` that can never be empty/null and forces the caller to set `model`.
+actions:
+  - target: $.components.schemas.ReportCreate.properties.spec.oneOf
+    remove: true
+  - target: $.components.schemas.ReportCreate.properties.spec.discriminator
+    remove: true
+  - target: $.components.schemas.ReportCreate.properties.spec
+    update:
+      type: object
+      required:
+        - model
+        - params
+      properties:
+        model:
+          type: string
+          description: >-
+            The report model. One of `transactions`, `transaction_retries`,
+            `detailed_settlement`, `accounts_receivables`.
+        params:
+          type: object
+          additionalProperties: true
+          description: The parameters for the report, specific to the model.

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -14,6 +14,7 @@ sources:
             - location: ./.speakeasy/overlays/fix-checkout-session-body.yaml
             - location: ./.speakeasy/overlays/fix-remove-unwanted-headers.yaml
             - location: ./.speakeasy/overlays/fix-add-x-forwarded-for-header.yaml
+            - location: ./.speakeasy/overlays/fix-report-spec-union.yaml
         registry:
             location: registry.speakeasyapi.dev/gr4vy/gr4vy/openapi
 targets:


### PR DESCRIPTION
## Problem (Sentry CORE-API-3AE)

`POST /reports` was 500ing with `AttributeError: 'NoneType' object has no attribute 'get'` because the C# SDK sent `spec: null`.

**Why the SDK emits `null`:** `ReportCreate.spec` is a discriminated `oneOf` of four report-spec variants. Speakeasy renders it as a `Spec` union whose writer (`SpecConverter.WriteJson`) emits a body **only when one of the variant members is set** — and the public `new Spec(SpecType type)` constructor lets you build a `Spec` with a discriminator but no body. That serializes the *required* `spec` field as `null`, which the API can't handle.

## Fix

The generated `Spec.cs` can't be hand-edited (it's regenerated by Speakeasy), so this fixes it at the **generation source** with a new overlay, `fix-report-spec-union.yaml`, registered in `workflow.yaml` (same pattern as `fix-checkout-session-body.yaml`).

It collapses `ReportCreate.spec` from a `oneOf` into a single **required object** `{ model, params }`. The four variants are structurally identical — `params` is a free-form object in every case — so the union adds no real type safety on the wire. After regen:

- `spec` generates as a plain model with **required** `Model` (string) + `Params` (dict).
- There is no union wrapper, no nullable members, and no bare discriminator constructor → **it can never serialize to `null`**, and `model` is forced.

Verified by simulating the overlay against the live `openapi.json`: the resulting `ReportCreate.spec` is a clean object schema with `required: [model, params]` and no `oneOf`/`discriminator`.

## Follow-up

This is a generation-config change; it takes effect on the next Speakeasy regen. After that, constructing a spec moves from `Spec.CreateTransactions(...)` to `new Spec { Model = "transactions", Params = ... }`, so the E2E `ReportsTest` (in #211) will need that one-line update when the regenerated SDK lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)