### PR TITLE
feat(auth): add getEmbedTokenWithCheckoutSession helper

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -1,0 +1,2 @@
+src/Gr4vy/Auth.cs
+src/Gr4vy.Tests/AuthTest.cs

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ var token = Auth.GetEmbedToken(
 ### Attaching a checkout session automatically
 
 For Embed, it is recommended to attach a checkout session to every transaction. The
-`Auth.GetEmbedTokenWithCheckoutSession` helper creates a checkout session using your SDK client and
+`Auth.GetEmbedTokenWithCheckoutSessionAsync` helper creates a checkout session using your SDK client and
 returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
 
 ```csharp
@@ -167,7 +167,7 @@ var sdk = new Gr4vySDK(
     merchantAccountId: "default"
 );
 
-var token = await Auth.GetEmbedTokenWithCheckoutSession(
+var token = await Auth.GetEmbedTokenWithCheckoutSessionAsync(
     client: sdk,
     privateKey: privateKey,
     embedParams: new Dictionary<string, object>

--- a/README.md
+++ b/README.md
@@ -128,22 +128,58 @@ var sdk = new Gr4vySDK(
     merchantAccountId: "default"
 );
 
-var checkoutSession = await sdk.CheckoutSessions.CreateAsync()
+var checkoutSession = await sdk.CheckoutSessions.CreateAsync();
 
-auth.get_embed_token(
-    privatekey,
-    embedParams=new Dictionary<string, object>
+var token = Auth.GetEmbedToken(
+    privateKey: privateKey,
+    embedParams: new Dictionary<string, object>
     {
-        ["amount"]: 1299,
-        ["currency"]: 'USD',
-        ["buyer_external_identifier"]: 'user-1234',
+        ["amount"] = 1299,
+        ["currency"] = "USD",
+        ["buyer_external_identifier"] = "user-1234",
     },
-    checkoutSessionId=checkoutSession.ID
-)
+    checkoutSessionId: checkoutSession.Id
+);
 ```
 
 > **Note:** This will only create a token once. Use `Auth.WithToken()` to dynamically generate a token
 > for every request.
+
+### Attaching a checkout session automatically
+
+For Embed, it is recommended to attach a checkout session to every transaction. The
+`Auth.GetEmbedTokenWithCheckoutSession` helper creates a checkout session using your SDK client and
+returns an Embed token with the resulting `checkout_session_id` already pinned, in a single call.
+
+```csharp
+using Gr4vy;
+
+// Loaded the key from a file, env variable, 
+// or anywhere else
+var privateKey = "..."; 
+
+var sdk = new Gr4vySDK(
+    id: "example",
+    server: SDKConfig.Server.Sandbox,
+    bearerAuthSource: Auth.WithToken(privateKey),
+    merchantAccountId: "default"
+);
+
+var token = await Auth.GetEmbedTokenWithCheckoutSession(
+    client: sdk,
+    privateKey: privateKey,
+    embedParams: new Dictionary<string, object>
+    {
+        ["amount"] = 1299,
+        ["currency"] = "USD",
+        ["buyer_external_identifier"] = "user-1234",
+    }
+);
+```
+
+You can optionally pass a `checkoutSession` body (a `CheckoutSessionCreate`) to seed the session
+(for example with cart items or metadata), and a `merchantAccountId` to override the client's
+configured merchant account.
 
 ## Merchant account ID selection
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ returns an Embed token with the resulting `checkout_session_id` already pinned, 
 
 ```csharp
 using Gr4vy;
+using System.Collections.Generic;
 
 // Load the key from a file, env variable,
 // or anywhere else

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Alternatively, you can create a token for use with Embed as follows.
 
 ```csharp
 using Gr4vy;
+using System.Collections.Generic;
 
 // Loaded the key from a file, env variable, 
 // or anywhere else
@@ -142,7 +143,7 @@ var token = Auth.GetEmbedToken(
 );
 ```
 
-> **Note:** This will only create a token once. Use `Auth.WithToken()` to dynamically generate a token
+> **Note:** This will only create a token once. Use `Auth.WithToken(privateKey)` to dynamically generate a token
 > for every request.
 
 ### Attaching a checkout session automatically

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ returns an Embed token with the resulting `checkout_session_id` already pinned, 
 ```csharp
 using Gr4vy;
 
-// Loaded the key from a file, env variable, 
+// Load the key from a file, env variable,
 // or anywhere else
-var privateKey = "..."; 
+var privateKey = "...";
 
 var sdk = new Gr4vySDK(
     id: "example",

--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -182,6 +182,12 @@ rw==
         var serverTask = Task.Run(async () =>
         {
             var context = await listener.GetContextAsync();
+            if (context.Request.HttpMethod != "POST" || context.Request.Url?.AbsolutePath != "/checkout/sessions")
+            {
+                context.Response.StatusCode = 404;
+                context.Response.OutputStream.Close();
+                return;
+            }
             createCalls++;
             var body = System.Text.Encoding.UTF8.GetBytes(
                 "{\"type\":\"checkout-session\",\"id\":\"" + CheckoutSessionId + "\"}"
@@ -218,7 +224,7 @@ rw==
         finally
         {
             listener.Close();
-            try { await serverTask; } catch { /* swallow errors from listener.Close() */ }
+            try { await serverTask; } catch (System.Net.HttpListenerException) { /* expected when Close() interrupts GetContextAsync() */ }
         }
     }
 

--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -160,11 +160,21 @@ rw==
         );
     }
 
+    private static int GetFreePort()
+    {
+        var tcp = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        tcp.Start();
+        var port = ((System.Net.IPEndPoint)tcp.LocalEndpoint).Port;
+        tcp.Stop();
+        return port;
+    }
+
     [Test]
     public async Task GetEmbedTokenWithCheckoutSession_ShouldPinCreatedCheckoutSessionId()
     {
+        var port = GetFreePort();
         var listener = new System.Net.HttpListener();
-        var prefix = "http://127.0.0.1:8723/";
+        var prefix = $"http://127.0.0.1:{port}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
 
@@ -186,7 +196,7 @@ rw==
         {
             var client = new Gr4vySDK(
                 bearerAuth: "test-token",
-                serverUrl: "http://127.0.0.1:8723"
+                serverUrl: $"http://127.0.0.1:{port}"
             );
 
             var token = await Auth.GetEmbedTokenWithCheckoutSession(
@@ -194,8 +204,6 @@ rw==
                 privateKey: PrivateKey,
                 embedParams: _embedParams
             );
-
-            await serverTask;
 
             var handler = new JwtSecurityTokenHandler();
             var jwtToken = handler.ReadJwtToken(token);
@@ -210,6 +218,7 @@ rw==
         finally
         {
             listener.Stop();
+            try { await serverTask; } catch { /* swallow errors from listener.Stop() */ }
         }
     }
 

--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -170,7 +170,7 @@ rw==
     }
 
     [Test]
-    public async Task GetEmbedTokenWithCheckoutSession_ShouldPinCreatedCheckoutSessionId()
+    public async Task GetEmbedTokenWithCheckoutSessionAsync_ShouldPinCreatedCheckoutSessionId()
     {
         var port = GetFreePort();
         var listener = new System.Net.HttpListener();
@@ -205,7 +205,7 @@ rw==
                 serverUrl: $"http://127.0.0.1:{port}"
             );
 
-            var token = await Auth.GetEmbedTokenWithCheckoutSession(
+            var token = await Auth.GetEmbedTokenWithCheckoutSessionAsync(
                 client: client,
                 privateKey: PrivateKey,
                 embedParams: _embedParams

--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;
+using Gr4vy;
 using NUnit.Framework;
 
 [TestFixture]
@@ -157,6 +158,59 @@ rw==
             jwtToken.Claims.First(c => c.Type == "checkout_session_id").Value,
             Is.EqualTo(CheckoutSessionId)
         );
+    }
+
+    [Test]
+    public async Task GetEmbedTokenWithCheckoutSession_ShouldPinCreatedCheckoutSessionId()
+    {
+        var listener = new System.Net.HttpListener();
+        var prefix = "http://127.0.0.1:8723/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+
+        var createCalls = 0;
+        var serverTask = Task.Run(async () =>
+        {
+            var context = await listener.GetContextAsync();
+            createCalls++;
+            var body = System.Text.Encoding.UTF8.GetBytes(
+                "{\"type\":\"checkout-session\",\"id\":\"" + CheckoutSessionId + "\"}"
+            );
+            context.Response.StatusCode = 201;
+            context.Response.ContentType = "application/json";
+            context.Response.OutputStream.Write(body, 0, body.Length);
+            context.Response.OutputStream.Close();
+        });
+
+        try
+        {
+            var client = new Gr4vySDK(
+                bearerAuth: "test-token",
+                serverUrl: "http://127.0.0.1:8723"
+            );
+
+            var token = await Auth.GetEmbedTokenWithCheckoutSession(
+                client: client,
+                privateKey: PrivateKey,
+                embedParams: _embedParams
+            );
+
+            await serverTask;
+
+            var handler = new JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(token);
+
+            Assert.That(createCalls, Is.EqualTo(1));
+            Assert.Contains(JWTScope.Embed, jwtToken.Claims.Select(c => c.Type).ToList());
+            Assert.That(
+                jwtToken.Claims.First(c => c.Type == "checkout_session_id").Value,
+                Is.EqualTo(CheckoutSessionId)
+            );
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     [Test]

--- a/src/Gr4vy.Tests/AuthTest.cs
+++ b/src/Gr4vy.Tests/AuthTest.cs
@@ -217,8 +217,8 @@ rw==
         }
         finally
         {
-            listener.Stop();
-            try { await serverTask; } catch { /* swallow errors from listener.Stop() */ }
+            listener.Close();
+            try { await serverTask; } catch { /* swallow errors from listener.Close() */ }
         }
     }
 

--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -300,6 +300,8 @@ public class Auth
         string? merchantAccountId = null
     )
     {
+        if (client == null) throw new ArgumentNullException(nameof(client));
+
         var session = await client.CheckoutSessions.CreateAsync(
             merchantAccountId: merchantAccountId,
             checkoutSessionCreate: checkoutSession

--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -291,7 +291,7 @@ public class Auth
     /// <param name="embedParams">An optional map of Embed params to pin.</param>
     /// <param name="checkoutSession">An optional checkout session body to seed cart items, metadata, and so on.</param>
     /// <param name="merchantAccountId">An optional merchant account ID override. Defaults to the client's configured one.</param>
-    /// <returns>A bearer auth token for use with Embed.</returns>
+    /// <returns>A signed JWT string for use with Embed.</returns>
     public static async Task<string> GetEmbedTokenWithCheckoutSession(
         IGr4vySDK client,
         string privateKey,

--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -292,7 +292,7 @@ public class Auth
     /// <param name="checkoutSession">An optional checkout session body to seed cart items, metadata, and so on.</param>
     /// <param name="merchantAccountId">An optional merchant account ID override. Defaults to the client's configured one.</param>
     /// <returns>A signed JWT string for use with Embed.</returns>
-    public static async Task<string> GetEmbedTokenWithCheckoutSession(
+    public static async Task<string> GetEmbedTokenWithCheckoutSessionAsync(
         IGr4vySDK client,
         string privateKey,
         Dictionary<string, object>? embedParams = null,

--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -6,7 +6,9 @@ using System.Reflection;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Gr4vy;
+using Gr4vy.Models.Components;
 using Microsoft.IdentityModel.Tokens;
 
 public static class JWTScope
@@ -273,5 +275,36 @@ public class Auth
             embedParams,
             checkoutSessionId
         );
+    }
+
+    /// <summary>
+    /// Creates a checkout session and returns an Embed token with its ID pinned.
+    /// </summary>
+    /// <remarks>
+    /// This is a convenience wrapper around <see cref="GetEmbedToken"/> for the common Embed
+    /// flow where every transaction should be tied to a checkout session. It uses the provided
+    /// (already authenticated) SDK client to create the checkout session, then signs an Embed
+    /// token that pins the resulting <c>checkout_session_id</c>.
+    /// </remarks>
+    /// <param name="client">An authenticated Gr4vy SDK client.</param>
+    /// <param name="privateKey">The EC private key in string-PEM format.</param>
+    /// <param name="embedParams">An optional map of Embed params to pin.</param>
+    /// <param name="checkoutSession">An optional checkout session body to seed cart items, metadata, and so on.</param>
+    /// <param name="merchantAccountId">An optional merchant account ID override. Defaults to the client's configured one.</param>
+    /// <returns>A bearer auth token for use with Embed.</returns>
+    public static async Task<string> GetEmbedTokenWithCheckoutSession(
+        IGr4vySDK client,
+        string privateKey,
+        Dictionary<string, object>? embedParams = null,
+        CheckoutSessionCreate? checkoutSession = null,
+        string? merchantAccountId = null
+    )
+    {
+        var session = await client.CheckoutSessions.CreateAsync(
+            merchantAccountId: merchantAccountId,
+            checkoutSessionCreate: checkoutSession
+        );
+
+        return GetEmbedToken(privateKey, embedParams, session.Id);
     }
 }


### PR DESCRIPTION
## What

Adds an opt-in `getEmbedTokenWithCheckoutSession` helper (idiomatic per language) that creates a checkout session via the SDK client and returns an Embed token with the resulting `checkout_session_id` already pinned — in a single call.

This makes it neat for merchants to ensure **every Embed transaction is tied to a checkout session**, without manually creating the session and threading its ID into the token call.

## Details

- **Non-breaking**: the existing `getEmbedToken` signature is unchanged. Passing the SDK client into the new helper is the opt-in.
- Accepts an optional checkout session body (cart items, metadata, etc.) and an optional merchant-account override; defaults to an empty session using the client's configured merchant account.
- The hand-written auth source and its test are now protected from Speakeasy regeneration via `.genignore`.
- New unit test covers: a checkout session is created exactly once and the returned token carries the `embed` scope and the pinned `checkout_session_id`.
- README "Embed token generation" section documents the new helper (these sections live outside Speakeasy's managed `<!-- Start/End -->` regions, so they survive regen).

Docs PR (token quickstart + JWT guide) is in `gr4vy-docs-mintlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
