### PR TITLE
test: cover API key pairs, transaction captures and refund settlements

### DIFF
--- a/src/Gr4vy.Tests/Backoffice/ApiKeyPairsTest.cs
+++ b/src/Gr4vy.Tests/Backoffice/ApiKeyPairsTest.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Gr4vy;
+using Gr4vy.Models.Components;
+using Gr4vy.Tests.Utils;
+using NUnit.Framework;
+
+namespace Gr4vy.Tests.Backoffice
+{
+    /// <summary>
+    /// API key pair endpoints. List is a happy path; create/get/update/delete are
+    /// reached at the request level. API key pairs are an ACCOUNT-LEVEL resource
+    /// (like merchant_accounts): they are not scoped to a single merchant account,
+    /// so — mirroring <see cref="MerchantAccountsTest"/> — the fixture's client is
+    /// fine (an account-level endpoint ignores the merchant-account header the
+    /// scoped client carries). Create requires a real role id and get/update/delete
+    /// require a real key-pair id, neither of which the isolated mock fixture
+    /// provisions, so those are driven to a clean 4xx instead of a 2xx.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable(ParallelScope.Self)]
+    public class ApiKeyPairsTest
+    {
+        private const string MissingId = "11111111-1111-1111-1111-111111111111";
+
+        private TestMerchant _m = null!;
+        private Gr4vySDK Client => _m.Client;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp() => _m = await TestEnvironment.SetupMerchantAsync();
+
+        [Test]
+        public async Task List_And_Reached()
+        {
+            var list = await Client.ApiKeyPairs.ListAsync();
+            Assert.That(list.Result, Is.Not.Null);
+
+            // Create references a nonexistent role id, so the request reaches the
+            // server and is cleanly rejected (no valid role to assign here).
+            await Reach.ReachesAsync(
+                () =>
+                    Client.ApiKeyPairs.CreateAsync(
+                        new APIKeyPairCreate
+                        {
+                            DisplayName = "SDK test key pair",
+                            RoleIds = new List<string> { MissingId },
+                        }
+                    ),
+                "api-key-pairs.create"
+            );
+
+            await Reach.ReachesAsync(
+                () => Client.ApiKeyPairs.GetAsync(MissingId),
+                "api-key-pairs.get"
+            );
+
+            await Reach.ReachesAsync(
+                () =>
+                    Client.ApiKeyPairs.UpdateAsync(
+                        MissingId,
+                        new APIKeyPairUpdate { DisplayName = "SDK test key pair (updated)" }
+                    ),
+                "api-key-pairs.update"
+            );
+
+            await Reach.ReachesAsync(
+                () => Client.ApiKeyPairs.DeleteAsync(MissingId),
+                "api-key-pairs.delete"
+            );
+        }
+    }
+}

--- a/src/Gr4vy.Tests/Flows/TransactionLifecycleTest.cs
+++ b/src/Gr4vy.Tests/Flows/TransactionLifecycleTest.cs
@@ -12,13 +12,15 @@ namespace Gr4vy.Tests.Flows
     /// The headline merchant story: authorize a card transaction directly against
     /// POST /transactions (the non-checkout-session path), then exercise the
     /// processing lifecycle — capture, refund, sync, list, update, and the
-    /// transaction sub-resources (actions, events, settlements). A separate
-    /// transaction is authorized then voided.
+    /// transaction sub-resources (actions, events, settlements, captures, refund
+    /// settlements). A separate transaction is authorized then voided.
     /// </summary>
     [TestFixture]
     [Parallelizable(ParallelScope.Self)]
     public class TransactionLifecycleTest
     {
+        private const string MissingId = "11111111-1111-1111-1111-111111111111";
+
         private TestMerchant _m = null!;
         private Gr4vySDK Client => _m.Client;
 
@@ -78,6 +80,17 @@ namespace Gr4vy.Tests.Flows
             var settlements = await Client.Transactions.Settlements.ListAsync(txn.Id);
             Assert.That(settlements, Is.Not.Null);
 
+            // 4b. Captures list (happy path — the transaction was captured above).
+            // Getting a specific capture is reached at the request level: the mock
+            // connector does not expose an addressable capture record to fetch by id.
+            var captures = await Client.Transactions.Captures.ListAsync(txn.Id);
+            Assert.That(captures, Is.Not.Null);
+
+            await Reach.ReachesAsync(
+                () => Client.Transactions.Captures.GetAsync(txn.Id, MissingId),
+                "transactions.captures.get"
+            );
+
             // 5. Refund the captured transaction (+ list + get)
             var refund = await Client.Transactions.Refunds.CreateAsync(
                 txn.Id,
@@ -95,6 +108,17 @@ namespace Gr4vy.Tests.Flows
             var topRefund = await Client.Refunds.GetAsync(refund.Id!);
             Assert.That(topRefund.Id, Is.EqualTo(refund.Id));
 
+            // 6b. Refund-settlements list (happy path). Getting a specific refund
+            // settlement is reached at the request level: the mock connector produces
+            // no settlement record to fetch by id.
+            var refundSettlements = await Client.Transactions.RefundSettlements.ListAsync(txn.Id);
+            Assert.That(refundSettlements, Is.Not.Null);
+
+            await Reach.ReachesAsync(
+                () => Client.Transactions.RefundSettlements.GetAsync(txn.Id, MissingId),
+                "transactions.refund-settlements.get"
+            );
+
             // 7. Refund-all + settlement get (reached at the request level — the
             // remaining balance may be zero after the partial refund above, and the
             // mock connector produces no settlement record to fetch by id).
@@ -103,7 +127,7 @@ namespace Gr4vy.Tests.Flows
                 "transactions.refunds.all.create"
             );
             await Reach.ReachesAsync(
-                () => Client.Transactions.Settlements.GetAsync(txn.Id, "11111111-1111-1111-1111-111111111111"),
+                () => Client.Transactions.Settlements.GetAsync(txn.Id, MissingId),
                 "transactions.settlements.get"
             );
         }


### PR DESCRIPTION
## The gap

CI's endpoint-coverage check only counts an endpoint as covered when a real HTTP request reaches the server. Several C# endpoints were showing as uncovered (C# lagged the other SDKs):

**API key pairs** — the generated `src/Gr4vy/ApiKeyPairs.cs` resource (`CreateAsync` / `ListAsync` / `GetAsync` / `UpdateAsync` / `DeleteAsync`) had zero tests.

**Transaction sub-resources** — four endpoints the other SDKs already cover on main, but C# never got:
- `GET /transactions/{id}/captures` (list)
- `GET /transactions/{id}/captures/{capture_id}` (get)
- `GET /transactions/{id}/refund-settlements` (list)
- `GET /transactions/{id}/refund-settlements/{settlement_id}` (get)

## The design

All tests mirror existing conventions (fixture setup via `TestEnvironment.SetupMerchantAsync`, NUnit `[Test]`, the shared `Reach` helper, and a `MissingId` constant).

**`src/Gr4vy.Tests/Backoffice/ApiKeyPairsTest.cs`** (new):
- `list` — happy path, asserts a non-null result.
- `create / get / update / delete` — reached at the request level via `Reach.ReachesAsync` (clean 4xx). Create references a nonexistent role id; get/update/delete use the missing-id constant.
- API key pairs are an account-level resource (like merchant accounts), so — as in `MerchantAccountsTest` — the fixture's merchant-scoped client is used directly; the account-level endpoint ignores the merchant-account header. A comment explains this.

**`src/Gr4vy.Tests/Flows/TransactionLifecycleTest.cs`** (extended — it already authorizes, captures and refunds a mock-card transaction):
- `captures.list` / `refund-settlements.list` — happy path, assert non-null.
- `captures.get` / `refund-settlements.get` — reached via `Reach.ReachesAsync` (the mock connector exposes no addressable capture or settlement record to fetch by id).
- Hoisted the inline missing-id literal to a `MissingId` constant.

## Verification

`dotnet build src/Gr4vy.Tests/` succeeds with 0 errors. The live suite was not run here (needs sandbox credentials); CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)