### PR TITLE
feat: add missing public JWT scopes

### DIFF
--- a/src/Gr4vy/Auth.cs
+++ b/src/Gr4vy/Auth.cs
@@ -20,12 +20,16 @@ public static class JWTScope
     public const string AntiFraudServiceDefinitionsWrite = "anti-fraud-service-definitions.write";
     public const string AntiFraudServicesRead = "anti-fraud-services.read";
     public const string AntiFraudServicesWrite = "anti-fraud-services.write";
+    public const string ApiKeyPairsRead = "api-key-pairs.read";
+    public const string ApiKeyPairsWrite = "api-key-pairs.write";
     public const string ApiLogsRead = "api-logs.read";
     public const string ApiLogsWrite = "api-logs.write";
     public const string ApplePayCertificatesRead = "apple-pay-certificates.read";
     public const string ApplePayCertificatesWrite = "apple-pay-certificates.write";
     public const string AuditLogsRead = "audit-logs.read";
     public const string AuditLogsWrite = "audit-logs.write";
+    public const string BinCheckerRead = "bin-checker.read";
+    public const string BinCheckerWrite = "bin-checker.write";
     public const string BuyersRead = "buyers.read";
     public const string BuyersWrite = "buyers.write";
     public const string BuyersBillingDetailsRead = "buyers.billing-details.read";
@@ -66,6 +70,8 @@ public static class JWTScope
     public const string ReportsWrite = "reports.write";
     public const string RolesRead = "roles.read";
     public const string RolesWrite = "roles.write";
+    public const string ThreeDSScenariosRead = "three-ds-scenarios.read";
+    public const string ThreeDSScenariosWrite = "three-ds-scenarios.write";
     public const string TransactionsRead = "transactions.read";
     public const string TransactionsWrite = "transactions.write";
     public const string UsersMeRead = "users.me.read";


### PR DESCRIPTION
## What

Adds three JWT scope pairs that exist in core-api's public scope set but were missing from this SDK's scope list:

- `api-key-pairs.read` / `api-key-pairs.write`
- `bin-checker.read` / `bin-checker.write`
- `three-ds-scenarios.read` / `three-ds-scenarios.write`

## Why

A merchant on the Java SDK hit this: they need to mint a JWT with `bin-checker.read`, but the scope isn't in the shipped scope enum, so there's no supported way to request it. The same three pairs were missing from all six SDKs (java, python, php, go, csharp, typescript) — matching PRs are open on each.

## How it was verified

Each scope string was checked against `RESOURCES` in core-api `src/api/helpers/auth.py`. All three are public API surface: guarded by `get_token` (not `get_staff_token`) and exposed with `include_in_schema=True`.

After this change the SDK scope list matches core-api's public scope set exactly (71 scopes, plus the `*.read` / `*.write` staff wildcards the SDKs already carried).

`business-contexts` was deliberately **not** added. It computes as public in core-api because it's flagged `internal=False`, but its endpoints require a staff token and are hidden from the schema — it looks like a stale flag in core-api rather than a genuinely public scope, and is being followed up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
