### PR TITLE
test: cover gift-card activations/issuances and authorization increment

### DIFF
--- a/src/Gr4vy.Tests/Processing/GiftCardsTest.cs
+++ b/src/Gr4vy.Tests/Processing/GiftCardsTest.cs
@@ -8,9 +8,10 @@ namespace Gr4vy.Tests.Processing
 {
     /// <summary>
     /// Gift card endpoints. The mock environment has no gift-card service, so
-    /// create/get/delete/balances are exercised at the request level (a real
-    /// request is sent and a documented API error is accepted) while list is a
-    /// happy path. This keeps every gift-card operation reached, never skipped.
+    /// create/get/delete/balances/activations/issuances are exercised at the
+    /// request level (a real request is sent and a documented API error is
+    /// accepted) while list is a happy path. This keeps every gift-card
+    /// operation reached, never skipped.
     /// </summary>
     [TestFixture]
     [Parallelizable(ParallelScope.Self)]
@@ -49,6 +50,43 @@ namespace Gr4vy.Tests.Processing
             await Reach.ReachesAsync(
                 () => Client.GiftCards.DeleteAsync(MissingId),
                 "gift-cards.delete"
+            );
+        }
+
+        [Test]
+        public async Task GiftCardActivation_IsReached()
+        {
+            // Activating a gift card needs a configured gift-card service.
+            await Reach.ReachesAsync(
+                () =>
+                    Client.GiftCards.Activations.CreateAsync(
+                        new GiftCardActivationCreate
+                        {
+                            Number = "4111111111111111",
+                            Pin = "1234",
+                            Amount = 1299,
+                            Currency = "USD",
+                        }
+                    ),
+                "gift-cards.activations.create"
+            );
+        }
+
+        [Test]
+        public async Task GiftCardIssuance_IsReached()
+        {
+            // Issuing a gift card needs a configured gift-card service with a theme.
+            await Reach.ReachesAsync(
+                () =>
+                    Client.GiftCards.Issuances.CreateAsync(
+                        new GiftCardIssuanceCreate
+                        {
+                            Theme = "default",
+                            Amount = 1299,
+                            Currency = "USD",
+                        }
+                    ),
+                "gift-cards.issuances.create"
             );
         }
     }

--- a/src/Gr4vy.Tests/Processing/TransactionsExtraTest.cs
+++ b/src/Gr4vy.Tests/Processing/TransactionsExtraTest.cs
@@ -9,8 +9,10 @@ namespace Gr4vy.Tests.Processing
 {
     /// <summary>
     /// Transaction operations not covered by the lifecycle flow: manual update
-    /// (metadata round-trip) and cancel (reached at the request level — an already
-    /// authorized mock transaction cannot be cancelled).
+    /// (metadata round-trip), cancel and authorization increment (both reached at
+    /// the request level — an already authorized mock transaction cannot be
+    /// cancelled, and the mock connector does not support incremental
+    /// authorization).
     /// </summary>
     [TestFixture]
     [Parallelizable(ParallelScope.Self)]
@@ -67,6 +69,22 @@ namespace Gr4vy.Tests.Processing
             await Reach.ReachesAsync(
                 () => Client.Transactions.CancelAsync(txn.Id),
                 "transactions.cancel"
+            );
+        }
+
+        [Test]
+        public async Task IncrementAuthorization_IsReached()
+        {
+            // Incremental authorization is a PSP capability the mock connector does
+            // not offer, so we authorize for real and accept a clean rejection.
+            var txn = await AuthorizeAsync();
+            await Reach.ReachesAsync(
+                () =>
+                    Client.Transactions.IncrementAuthorizationAsync(
+                        txn.Id,
+                        new TransactionAuthorizationIncrementCreate { Amount = 500 }
+                    ),
+                "transactions.increment-authorization"
             );
         }
     }


### PR DESCRIPTION
## Why

The endpoint-reach report has been sitting at **116 / 119** on every SDK. The same three operations were never hitting the wire:

- `POST /gift-cards/activations`
- `POST /gift-cards/issuances`
- `POST /transactions/{transaction_id}/authorization/increment`

This closes the gap for C#. Companion PRs cover the other five SDKs.

## What

- `GiftCardsTest.cs` — `GiftCardActivation_IsReached`, `GiftCardIssuance_IsReached`
- `TransactionsExtraTest.cs` — `IncrementAuthorization_IsReached`

All three need capabilities the mock-card merchant does not have (a configured gift-card service; a PSP that supports incremental authorization), so they follow the existing `Reach.ReachesAsync` convention: a 2xx or a clean 4xx passes, a **5xx fails**. The increment test authorizes a real transaction first, so the increment is attempted against a genuinely authorized transaction rather than a missing id.

## Verification

⚠️ I have no .NET SDK on this machine, so I could not build locally — CI here is the first real check. I verified against the generated sources instead: `IGiftCards.Activations`/`Issuances`, `IActivations`/`IIssuances.CreateAsync`, the component property names and types, and the `(transactionId, body)` argument order on `IncrementAuthorizationAsync` (note this is the reverse of the PHP ordering).

The `coverage` job is the coverage verification — it should report **119 / 119**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)